### PR TITLE
fix: Add support for skip verify env variable and update local development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ terraform {
 
 # Initialize the provider
 provider "cofide" {
-  api_token = "your_api_token"
+  api_token   = "your_api_token"
+  connect_url = "foo.cofide.dev:8443"
 }
 
 # Configure a resource
@@ -75,7 +76,7 @@ To use this provider locally:
 
    provider "cofide" {
      api_token            = "your_api_token"
-     connect_url          = "https://localhost:8443" # or your local instance URL
+     connect_url          = "foo.cofide.dev:8443"
      insecure_skip_verify = true                     # Only use this for local development
    }
    ```
@@ -102,11 +103,8 @@ To use this provider locally:
    terraform apply
    ```
 
----
-
-To generate or update documentation for the provider, run:
+To generate or update documentation for the provider, run the following command from the project root:
 
 ```bash
 just generate
 ```
-from the project root.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Initialize your project by running `terraform init` in the directory.
 
 To use this provider locally:
 
-1. **Build and install the provider locally:**
+1. **Build the provider locally:**
 
    ```bash
-   just install
+   just build
    ```
    This will:
    - Build the provider and install it in `bin/terraform-provider-cofide`
@@ -58,6 +58,7 @@ To use this provider locally:
      dev_overrides {
        "cofide/cofide" = "/<PATH-TO-REPO>/terraform-provider-cofide/bin"
      }
+
      direct {}
    }
    ```
@@ -93,14 +94,14 @@ To use this provider locally:
 4. **Initialize your Terraform project:**
 
    ```bash
-   terraform init
+   TF_CLI_CONFIG_FILE=./dev.tfrc terraform init
    ```
 
 5. **Use the provider as normal:**
 
    ```bash
-   terraform plan
-   terraform apply
+   TF_CLI_CONFIG_FILE=./dev.tfrc terraform plan
+   TF_CLI_CONFIG_FILE=./dev.tfrc terraform apply
    ```
 
 To generate or update documentation for the provider, run the following command from the project root:

--- a/README.md
+++ b/README.md
@@ -41,45 +41,72 @@ Initialize your project by running `terraform init` in the directory.
 
 To use this provider locally:
 
-1. Build and install the provider locally:
+1. **Build and install the provider locally:**
+
    ```bash
    just install
    ```
    This will:
-   - Build the provider
-   - Install it to `~/.terraform.d/plugins/local/cofide/cofide/0.1.0/<os>_<arch>`
+   - Build the provider and install it in `bin/terraform-provider-cofide`
 
-3. In your Terraform configuration, use the local provider:
+2. **Create a `dev.tfrc` file to enable local provider development**  
+   (see [Terraform docs](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) for more info):
+
+   ```
+   provider_installation {
+     dev_overrides {
+       "cofide/cofide" = "/<PATH-TO-REPO>/terraform-provider-cofide/bin"
+     }
+     direct {}
+   }
+   ```
+
+3. **Configure your Terraform project:**
+
    ```hcl
    terraform {
      required_providers {
        cofide = {
-         source  = "local/cofide/cofide"
+         source  = "cofide/cofide"
          version = "0.1.0"
        }
      }
    }
 
    provider "cofide" {
-     api_token   = "your_api_token"
-     connect_url = "foo.cofide.dev:8443"
+     api_token            = "your_api_token"
+     connect_url          = "https://localhost:8443" # or your local instance URL
+     insecure_skip_verify = true                     # Only use this for local development
    }
    ```
 
-   The `connect_url` will be provided to you by Cofide.
+   - The `connect_url` will be provided to you by Cofide, or use your local instance URL for development.
+   - Instead of using the `connect_url` and `api_token` attributes, you can set the `COFIDE_CONNECT_URL` and `COFIDE_API_TOKEN` environment variables.
+   - To retrieve an API token, authenticate with Connect using `cofidectl connect login`. The token can be found in `~/.cofide/credentials`.
 
-   Instead of using the `connect_url` attribute, you can also set the `COFIDE_CONNECT_URL` environment variable. As an alternative to setting the `api_token` attribute, you can use the `COFIDE_API_TOKEN` environment variable instead. To retrieve an API token, you must authenticate with Connect in the usual way via the `cofidectl connect login` command. The API token can be extracted from the generated `~/.cofide/credentials` file.
+   - If you are running a local instance of Connect, update your `/etc/hosts` file to include:
+     ```
+     <connect-api-load-balancer-service-ip> connect.cofide.security
+     ```
 
-   If you are running a local instance of Connect, you'll need to update your `etc/hosts` file to include the following:
-   ```
-   <connect-api-load-balancer-service-ip> connect.cofide.security
-   ```
+4. **Initialize your Terraform project:**
 
-4. Initialize your Terraform project as normal:
    ```bash
    terraform init
    ```
-   
-5. Now you can use the provider with `terraform plan` and `terraform apply` as normal.
 
-To generate or update documentation for the provider, run `just generate` from the project root.
+5. **Use the provider as normal:**
+
+   ```bash
+   terraform plan
+   terraform apply
+   ```
+
+---
+
+To generate or update documentation for the provider, run:
+
+```bash
+just generate
+```
+from the project root.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ This project is the official Terraform provider for Cofide.
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }

--- a/test/connect_ap_binding/versions.tf
+++ b/test/connect_ap_binding/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }

--- a/test/connect_attestation_policy/versions.tf
+++ b/test/connect_attestation_policy/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }

--- a/test/connect_cluster/versions.tf
+++ b/test/connect_cluster/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }

--- a/test/connect_federation/versions.tf
+++ b/test/connect_federation/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }

--- a/test/connect_trust_zone/versions.tf
+++ b/test/connect_trust_zone/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cofide = {
-      source  = "local/cofide/cofide"
+      source  = "cofide/cofide"
       version = "0.1.0"
     }
   }


### PR DESCRIPTION
### Summary
- This PR adds a fix to ensure that the `COFIDE_SKIP_INSECURE_VERIFY` env variable can be used by the provider for local testing.
- The `README.md` has also been updated to outline how local development can be performed.