### PR TITLE
feat: Add a user agent string to the client

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,7 +32,7 @@ func (j *jwtCredentials) RequireTransportSecurity() bool {
 }
 
 // NewTLSClient creates a new gPRC client with TLS credentials.
-func NewTLSClient(baseAddr string, jwtToken string, insecureSkipVerify bool, logger hclog.Logger) (sdkclient.ClientSet, error) {
+func NewTLSClient(baseAddr string, jwtToken string, insecureSkipVerify bool, logger hclog.Logger, version string) (sdkclient.ClientSet, error) {
 	serverName, err := getServerName(baseAddr)
 	if err != nil {
 		return nil, err
@@ -63,6 +63,7 @@ func NewTLSClient(baseAddr string, jwtToken string, insecureSkipVerify bool, log
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithPerRPCCredentials(&jwtCredentials{token: jwtToken}),
 		grpc.WithDefaultServiceConfig(retryPolicy),
+		grpc.WithUserAgent(fmt.Sprintf("terraform-provider-cofide/%s", version)),
 	}
 
 	connectUri := fmt.Sprintf("dns:///%s.%s", consts.ServerAuthoritySubdomain, baseAddr)

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -127,7 +127,7 @@ func (p *CofideProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		Name: "cofide",
 	})
 
-	client, err := client.NewTLSClient(connectURL, apiToken, insecureSkipVerify, log)
+	client, err := client.NewTLSClient(connectURL, apiToken, insecureSkipVerify, log, p.version)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create TLS client", err.Error())
 		return


### PR DESCRIPTION
### Summary
- This PR adds a `WithUserAgent` DialOption to add a user agent string in each gRPC request, to be surfaced in `connect` as shown below:
```
{"bytes_received":39,"bytes_sent":283,"client_ip":"omitted","duration":340,"filter_chain_name":"connect_api","grpc_status":"OK","method":"POST","protocol":"HTTP/2","requested_server_name":"omitted","response_code":200,"timestamp":"2025-05-14T18:22:08.875Z","upstream_cluster":"connect_service","upstream_host":"omitted","upstream_local_address":"omitted","uri":"/proto.connect.trust_zone_service.v1alpha1.TrustZoneService/CreateTrustZone","user_agent":"terraform-provider-cofide/dev grpc-go/1.72.0"}
```
- This will help with debugging requests between different versions of the provider.