### PR TITLE
chore: Replace GitHub Actions variables with secrets in the `release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,30 +24,30 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/terraform-provider-cofide-gh-actions-access
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/terraform-provider-cofide-gh-actions-access
           role-session-name: terraform-provider-cofide-gh-actions-access
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Import GPG key
         run: |
-          GPG_FINGERPRINT_SECRET_ARN="arn:aws:secretsmanager:${{ vars.AWS_REGION }}:${{ vars.AWS_ACCOUNT_ID }}:secret:cofide/shared/terraform-provider-cofide-gpg-fingerprint-lbsrcV"
+          GPG_FINGERPRINT_SECRET_ARN="arn:aws:secretsmanager:${{ secrets.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:secret:cofide/shared/terraform-provider-cofide-gpg-fingerprint-lbsrcV"
           GPG_FINGERPRINT=$(aws secretsmanager get-secret-value \
             --secret-id $GPG_FINGERPRINT_SECRET_ARN \
-            --region ${{env.AWS_REGION }} \
+            --region ${{ secrets.AWS_REGION }} \
             --query 'SecretString' \
             --output text)
           echo "::add-mask::$GPG_FINGERPRINT"
           echo "GPG_FINGERPRINT=$GPG_FINGERPRINT" >> $GITHUB_ENV
 
-          GPG_PASSPHRASE_SECRET_ARN="arn:aws:secretsmanager:${{ vars.AWS_REGION }}:${{ vars.AWS_ACCOUNT_ID }}:secret:cofide/shared/terraform-provider-cofide-gpg-passphrase-7FBwwt"
+          GPG_PASSPHRASE_SECRET_ARN="arn:aws:secretsmanager:${{ secrets.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:secret:cofide/shared/terraform-provider-cofide-gpg-passphrase-7FBwwt"
           GPG_PASSPHRASE=$(aws secretsmanager get-secret-value \
             --secret-id $GPG_PASSPHRASE_SECRET_ARN \
-            --region ${{env.AWS_REGION }} \
+            --region ${{ secrets.AWS_REGION }} \
             --query 'SecretString' \
             --output text)
           echo "::add-mask::$GPG_PASSPHRASE"
           echo "GPG_PASSPHRASE=$GPG_PASSPHRASE" >> $GITHUB_ENV
 
-          GPG_PRIVATE_KEY_SECRET_ARN="arn:aws:secretsmanager:${{ vars.AWS_REGION }}:${{ vars.AWS_ACCOUNT_ID }}:secret:cofide/shared/terraform-provider-cofide-gpg-private-key-d0AUtD"
+          GPG_PRIVATE_KEY_SECRET_ARN="arn:aws:secretsmanager:${{ secrets.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:secret:cofide/shared/terraform-provider-cofide-gpg-private-key-d0AUtD"
           aws secretsmanager get-secret-value \
             --secret-id $GPG_PRIVATE_KEY_SECRET_ARN \
             --query 'SecretString' \


### PR DESCRIPTION
### Summary
- This PR makes a small change to use GitHub Actions secrets instead of env variables in the `release` workflow.