### PR TITLE
fix: use types.List for tpm_node selector_values to support unknown values during planning

### DIFF
--- a/internal/services/attestationpolicy/convert.go
+++ b/internal/services/attestationpolicy/convert.go
@@ -5,13 +5,16 @@ import (
 
 	attestationpolicypb "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	tftypes "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	spiretypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 )
 
 // modelToProto converts an AttestationPolicyModel to an equivalent AttestationPolicy protobuf.
-func modelToProto(ctx context.Context, model AttestationPolicyModel) *attestationpolicypb.AttestationPolicy {
+func modelToProto(ctx context.Context, model AttestationPolicyModel) (*attestationpolicypb.AttestationPolicy, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
 	proto := &attestationpolicypb.AttestationPolicy{
 		Id:    model.ID.ValueStringPointer(),
 		Name:  model.Name.ValueString(),
@@ -43,20 +46,20 @@ func modelToProto(ctx context.Context, model AttestationPolicyModel) *attestatio
 	}
 
 	if model.TPMNode != nil {
-		var selectorValues []tftypes.String
-		model.TPMNode.SelectorValues.ElementsAs(ctx, &selectorValues, false)
+		var selectorValues []string
+		diags.Append(model.TPMNode.SelectorValues.ElementsAs(ctx, &selectorValues, false)...)
 		tpmNodePolicy := &attestationpolicypb.APTPMNode{
 			Attestation: &attestationpolicypb.TPMAttestation{
 				EkHash: model.TPMNode.Attestation.EKHash.ValueStringPointer(),
 			},
-			SelectorValues: convertStringSlice(selectorValues),
+			SelectorValues: selectorValues,
 		}
 		proto.Policy = &attestationpolicypb.AttestationPolicy_TpmNode{
 			TpmNode: tpmNodePolicy,
 		}
 	}
 
-	return proto
+	return proto, diags
 }
 
 // protoToModel converts an AttestationPolicy protobuf to an equivalent AttestationPolicyModel.
@@ -181,7 +184,11 @@ func convertProtoStringSlice(input []string) []tftypes.String {
 }
 
 // convertProtoSelectorValues converts a slice of strings from protobuf to a Terraform types.List.
+// Returns a null list when input is empty.
 func convertProtoSelectorValues(input []string) tftypes.List {
+	if len(input) == 0 {
+		return tftypes.ListNull(tftypes.StringType)
+	}
 	elems := make([]attr.Value, 0, len(input))
 	for _, s := range input {
 		elems = append(elems, tftypes.StringValue(s))

--- a/internal/services/attestationpolicy/convert.go
+++ b/internal/services/attestationpolicy/convert.go
@@ -1,6 +1,8 @@
 package attestationpolicy
 
 import (
+	"context"
+
 	attestationpolicypb "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	tftypes "github.com/hashicorp/terraform-plugin-framework/types"
@@ -9,7 +11,7 @@ import (
 )
 
 // modelToProto converts an AttestationPolicyModel to an equivalent AttestationPolicy protobuf.
-func modelToProto(model AttestationPolicyModel) *attestationpolicypb.AttestationPolicy {
+func modelToProto(ctx context.Context, model AttestationPolicyModel) *attestationpolicypb.AttestationPolicy {
 	proto := &attestationpolicypb.AttestationPolicy{
 		Id:    model.ID.ValueStringPointer(),
 		Name:  model.Name.ValueString(),
@@ -41,11 +43,13 @@ func modelToProto(model AttestationPolicyModel) *attestationpolicypb.Attestation
 	}
 
 	if model.TPMNode != nil {
+		var selectorValues []tftypes.String
+		model.TPMNode.SelectorValues.ElementsAs(ctx, &selectorValues, false)
 		tpmNodePolicy := &attestationpolicypb.APTPMNode{
 			Attestation: &attestationpolicypb.TPMAttestation{
 				EkHash: model.TPMNode.Attestation.EKHash.ValueStringPointer(),
 			},
-			SelectorValues: convertStringSlice(model.TPMNode.SelectorValues),
+			SelectorValues: convertStringSlice(selectorValues),
 		}
 		proto.Policy = &attestationpolicypb.AttestationPolicy_TpmNode{
 			TpmNode: tpmNodePolicy,
@@ -83,7 +87,7 @@ func protoToModel(proto *attestationpolicypb.AttestationPolicy) AttestationPolic
 
 	if tpmNode := proto.GetTpmNode(); tpmNode != nil {
 		model.TPMNode = &APTPMNodeModel{
-			SelectorValues: convertProtoStringSlice(tpmNode.GetSelectorValues()),
+			SelectorValues: convertProtoSelectorValues(tpmNode.GetSelectorValues()),
 		}
 		if attestation := tpmNode.GetAttestation(); attestation != nil {
 			model.TPMNode.Attestation.EKHash = optionalStringValue(attestation.EkHash)
@@ -174,6 +178,15 @@ func convertProtoStringSlice(input []string) []tftypes.String {
 		result = append(result, tftypes.StringValue(t))
 	}
 	return result
+}
+
+// convertProtoSelectorValues converts a slice of strings from protobuf to a Terraform types.List.
+func convertProtoSelectorValues(input []string) tftypes.List {
+	elems := make([]attr.Value, 0, len(input))
+	for _, s := range input {
+		elems = append(elems, tftypes.StringValue(s))
+	}
+	return tftypes.ListValueMust(tftypes.StringType, elems)
 }
 
 // selectorAttrTypes defines the attribute types for a single selector object.

--- a/internal/services/attestationpolicy/model.go
+++ b/internal/services/attestationpolicy/model.go
@@ -38,7 +38,7 @@ type APStaticModel struct {
 
 type APTPMNodeModel struct {
 	Attestation    TPMAttestationModel `tfsdk:"attestation"`
-	SelectorValues []tftypes.String    `tfsdk:"selector_values"`
+	SelectorValues tftypes.List        `tfsdk:"selector_values"`
 }
 
 type TPMAttestationModel struct {

--- a/internal/services/attestationpolicy/resource.go
+++ b/internal/services/attestationpolicy/resource.go
@@ -55,7 +55,12 @@ func (r *AttestationPolicyResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	policy := modelToProto(ctx, plan)
+	policy, diags := modelToProto(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createResp, err := r.client.AttestationPolicyV1Alpha1().CreateAttestationPolicy(ctx, policy)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -117,7 +122,11 @@ func (r *AttestationPolicyResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	policy := modelToProto(ctx, plan)
+	policy, diags := modelToProto(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	policy.Id = &policyID
 
 	updateResp, err := r.client.AttestationPolicyV1Alpha1().UpdateAttestationPolicy(ctx, policy)

--- a/internal/services/attestationpolicy/resource.go
+++ b/internal/services/attestationpolicy/resource.go
@@ -55,7 +55,7 @@ func (r *AttestationPolicyResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	policy := modelToProto(plan)
+	policy := modelToProto(ctx, plan)
 	createResp, err := r.client.AttestationPolicyV1Alpha1().CreateAttestationPolicy(ctx, policy)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -117,7 +117,7 @@ func (r *AttestationPolicyResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	policy := modelToProto(plan)
+	policy := modelToProto(ctx, plan)
 	policy.Id = &policyID
 
 	updateResp, err := r.client.AttestationPolicyV1Alpha1().UpdateAttestationPolicy(ctx, policy)

--- a/test/connect_attestation_policy/main.tf
+++ b/test/connect_attestation_policy/main.tf
@@ -56,10 +56,15 @@ resource "cofide_connect_attestation_policy" "attestation_policy_tpm_node" {
     attestation = {
       ek_hash = "5b3e0a049837688b09028ba84be190720bcc8f6cf74a487dc53b2ce9f376b5fb"
     }
-    selector_values = [
-      "test-selector"
-    ]
+    selector_values = var.selector_values
   }
+}
+
+# Use a variable rather than a literal list of strings for selector values to
+# cover https://github.com/cofide/terraform-provider-cofide/issues/113.
+variable "selector_values" {
+  type = list(string)
+  default = ["test-selector"]
 }
 
 data "cofide_connect_attestation_policy" "attestation_policy_static" {


### PR DESCRIPTION
The framework cannot convert an unknown value into a Go slice ([]types.String),
so selector_values must be types.List. Update modelToProto to use ElementsAs and
protoToModel to construct a ListValue.

Fixes: #113

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
