### PR TITLE
fix: use types.List instead of []types.String

### DIFF
--- a/docs/data-sources/connect_trust_zone_server.md
+++ b/docs/data-sources/connect_trust_zone_server.md
@@ -64,7 +64,7 @@ output "trust_zone_server_cluster_id" {
 - `helm_values` (String) Helm values configured for the server install (JSON).
 - `kubernetes_namespace` (String) The Kubernetes namespace in which the server is deployed.
 - `kubernetes_service_account` (String) The name of the Kubernetes service account deployed with the server.
-- `org_id` (String) The ID of the organisation.
+- `org_id` (String) The ID of the organization.
 - `status` (Attributes) The current lifecycle status of the trust zone server. (see [below for nested schema](#nestedatt--status))
 - `trust_zone_id` (String) The ID of the trust zone managed by this server.
 

--- a/docs/data-sources/connect_trust_zone_servers.md
+++ b/docs/data-sources/connect_trust_zone_servers.md
@@ -48,7 +48,7 @@ output "trust_zone_server_ids" {
 ### Optional
 
 - `cluster_id` (String) Filter by cluster ID.
-- `org_id` (String) Filter by organisation ID.
+- `org_id` (String) Filter by organization ID.
 - `trust_zone_id` (String) Filter by trust zone ID.
 
 ### Read-Only
@@ -66,7 +66,7 @@ Read-Only:
 - `id` (String) The ID of the trust zone server.
 - `kubernetes_namespace` (String) The Kubernetes namespace in which the server is deployed.
 - `kubernetes_service_account` (String) The name of the Kubernetes service account deployed with the server.
-- `org_id` (String) The ID of the organisation.
+- `org_id` (String) The ID of the organization.
 - `status` (Attributes) The current lifecycle status of the trust zone server. (see [below for nested schema](#nestedatt--trust_zone_servers--status))
 - `trust_zone_id` (String) The ID of the trust zone managed by this server.
 

--- a/docs/resources/connect_trust_zone_server.md
+++ b/docs/resources/connect_trust_zone_server.md
@@ -122,7 +122,7 @@ output "trust_zone_server_id" {
 ### Read-Only
 
 - `id` (String) The ID of the trust zone server.
-- `org_id` (String) The ID of the organisation. Derived from the trust zone by Cofide Connect.
+- `org_id` (String) The ID of the organization. Derived from the trust zone by Cofide Connect.
 - `status` (Attributes) The current lifecycle status of the trust zone server. Set by Cofide Connect. (see [below for nested schema](#nestedatt--status))
 
 <a id="nestedatt--connect_k8s_psat_config"></a>

--- a/internal/services/attestationpolicy/convert.go
+++ b/internal/services/attestationpolicy/convert.go
@@ -22,10 +22,12 @@ func modelToProto(ctx context.Context, model AttestationPolicyModel) (*attestati
 	}
 
 	if model.Kubernetes != nil {
+		var dnsNameTemplates []string
+		diags.Append(model.Kubernetes.DnsNameTemplates.ElementsAs(ctx, &dnsNameTemplates, false)...)
 		k8sPolicy := &attestationpolicypb.APKubernetes{
-			NamespaceSelector:    convertLabelSelector(model.Kubernetes.NamespaceSelector),
-			PodSelector:          convertLabelSelector(model.Kubernetes.PodSelector),
-			DnsNameTemplates:     convertStringSlice(model.Kubernetes.DnsNameTemplates),
+			NamespaceSelector:    convertLabelSelector(ctx, model.Kubernetes.NamespaceSelector, &diags),
+			PodSelector:          convertLabelSelector(ctx, model.Kubernetes.PodSelector, &diags),
+			DnsNameTemplates:     dnsNameTemplates,
 			SpiffeIdPathTemplate: model.Kubernetes.SpiffeIDPathTemplate.ValueStringPointer(),
 		}
 		proto.Policy = &attestationpolicypb.AttestationPolicy_Kubernetes{
@@ -34,11 +36,13 @@ func modelToProto(ctx context.Context, model AttestationPolicyModel) (*attestati
 	}
 
 	if model.Static != nil {
+		var dnsNames []string
+		diags.Append(model.Static.DNSNames.ElementsAs(ctx, &dnsNames, false)...)
 		staticPolicy := &attestationpolicypb.APStatic{
 			SpiffeIdPath: model.Static.SpiffeIDPath.ValueStringPointer(),
 			ParentIdPath: model.Static.ParentIdPath.ValueStringPointer(),
 			Selectors:    convertSelectors(model.Static.Selectors),
-			DnsNames:     convertStringSlice(model.Static.DNSNames),
+			DnsNames:     dnsNames,
 		}
 		proto.Policy = &attestationpolicypb.AttestationPolicy_Static{
 			Static: staticPolicy,
@@ -74,7 +78,7 @@ func protoToModel(proto *attestationpolicypb.AttestationPolicy) AttestationPolic
 		model.Kubernetes = &APKubernetesModel{
 			NamespaceSelector:    convertProtoLabelSelector(k8s.NamespaceSelector),
 			PodSelector:          convertProtoLabelSelector(k8s.PodSelector),
-			DnsNameTemplates:     convertProtoStringSlice(k8s.GetDnsNameTemplates()),
+			DnsNameTemplates:     convertProtoSelectorValues(k8s.GetDnsNameTemplates()),
 			SpiffeIDPathTemplate: optionalStringValue(k8s.SpiffeIdPathTemplate),
 		}
 	}
@@ -84,7 +88,7 @@ func protoToModel(proto *attestationpolicypb.AttestationPolicy) AttestationPolic
 			SpiffeIDPath: optionalStringValue(static.SpiffeIdPath),
 			ParentIdPath: optionalStringValue(static.ParentIdPath),
 			Selectors:    convertProtoSelectors(static.GetSelectors()),
-			DNSNames:     convertProtoStringSlice(static.GetDnsNames()),
+			DNSNames:     convertProtoSelectorValues(static.GetDnsNames()),
 		}
 	}
 
@@ -100,7 +104,7 @@ func protoToModel(proto *attestationpolicypb.AttestationPolicy) AttestationPolic
 	return model
 }
 
-func convertLabelSelector(selector *APLabelSelectorModel) *attestationpolicypb.APLabelSelector {
+func convertLabelSelector(ctx context.Context, selector *APLabelSelectorModel, diags *diag.Diagnostics) *attestationpolicypb.APLabelSelector {
 	if selector == nil {
 		return nil
 	}
@@ -123,9 +127,9 @@ func convertLabelSelector(selector *APLabelSelectorModel) *attestationpolicypb.A
 			Key:      expr.Key.ValueString(),
 			Operator: expr.Operator.ValueString(),
 		}
-		for _, v := range expr.Values {
-			matchExpr.Values = append(matchExpr.Values, v.ValueString())
-		}
+		var values []string
+		diags.Append(expr.Values.ElementsAs(ctx, &values, false)...)
+		matchExpr.Values = values
 		result.MatchExpressions = append(result.MatchExpressions, matchExpr)
 	}
 
@@ -155,31 +159,11 @@ func convertProtoLabelSelector(selector *attestationpolicypb.APLabelSelector) *A
 		matchExpr := APMatchExpressionModel{
 			Key:      tftypes.StringValue(expr.GetKey()),
 			Operator: tftypes.StringValue(expr.GetOperator()),
-		}
-		for _, v := range expr.GetValues() {
-			matchExpr.Values = append(matchExpr.Values, tftypes.StringValue(v))
+			Values:   convertProtoSelectorValues(expr.GetValues()),
 		}
 		result.MatchExpressions = append(result.MatchExpressions, matchExpr)
 	}
 
-	return result
-}
-
-// convertStringSlice converts a slice of strings from Terraform to protobuf types.
-func convertStringSlice(input []tftypes.String) []string {
-	var result []string
-	for _, s := range input {
-		result = append(result, s.ValueString())
-	}
-	return result
-}
-
-// convertProtoStringSlice converts a slice of strings from protobuf to Terraform types.
-func convertProtoStringSlice(input []string) []tftypes.String {
-	var result []tftypes.String
-	for _, t := range input {
-		result = append(result, tftypes.StringValue(t))
-	}
 	return result
 }
 

--- a/internal/services/attestationpolicy/data_source.go
+++ b/internal/services/attestationpolicy/data_source.go
@@ -101,7 +101,7 @@ func (d *AttestationPolicyDataSource) Read(ctx context.Context, req datasource.R
 		if ps := k8s.GetPodSelector(); ps != nil {
 			state.Kubernetes.PodSelector = convertProtoLabelSelector(ps)
 		}
-		state.Kubernetes.DnsNameTemplates = convertProtoStringSlice(k8s.GetDnsNameTemplates())
+		state.Kubernetes.DnsNameTemplates = convertProtoSelectorValues(k8s.GetDnsNameTemplates())
 		state.Kubernetes.SpiffeIDPathTemplate = types.StringValue(k8s.GetSpiffeIdPathTemplate())
 	}
 
@@ -110,7 +110,7 @@ func (d *AttestationPolicyDataSource) Read(ctx context.Context, req datasource.R
 			SpiffeIDPath: types.StringValue(static.GetSpiffeIdPath()),
 			ParentIdPath: types.StringValue(static.GetParentIdPath()),
 			Selectors:    convertProtoSelectors(static.GetSelectors()),
-			DNSNames:     convertProtoStringSlice(static.GetDnsNames()),
+			DNSNames:     convertProtoSelectorValues(static.GetDnsNames()),
 		}
 	}
 

--- a/internal/services/attestationpolicy/model.go
+++ b/internal/services/attestationpolicy/model.go
@@ -14,7 +14,7 @@ type AttestationPolicyModel struct {
 type APKubernetesModel struct {
 	NamespaceSelector    *APLabelSelectorModel `tfsdk:"namespace_selector"`
 	PodSelector          *APLabelSelectorModel `tfsdk:"pod_selector"`
-	DnsNameTemplates     []tftypes.String      `tfsdk:"dns_name_templates"`
+	DnsNameTemplates     tftypes.List          `tfsdk:"dns_name_templates"`
 	SpiffeIDPathTemplate tftypes.String        `tfsdk:"spiffe_id_path_template"`
 }
 
@@ -24,16 +24,16 @@ type APLabelSelectorModel struct {
 }
 
 type APMatchExpressionModel struct {
-	Key      tftypes.String   `tfsdk:"key"`
-	Operator tftypes.String   `tfsdk:"operator"`
-	Values   []tftypes.String `tfsdk:"values"`
+	Key      tftypes.String `tfsdk:"key"`
+	Operator tftypes.String `tfsdk:"operator"`
+	Values   tftypes.List   `tfsdk:"values"`
 }
 
 type APStaticModel struct {
-	SpiffeIDPath tftypes.String   `tfsdk:"spiffe_id_path"`
-	ParentIdPath tftypes.String   `tfsdk:"parent_id_path"`
-	Selectors    tftypes.List     `tfsdk:"selectors"`
-	DNSNames     []tftypes.String `tfsdk:"dns_names"`
+	SpiffeIDPath tftypes.String `tfsdk:"spiffe_id_path"`
+	ParentIdPath tftypes.String `tfsdk:"parent_id_path"`
+	Selectors    tftypes.List   `tfsdk:"selectors"`
+	DNSNames     tftypes.List   `tfsdk:"dns_names"`
 }
 
 type APTPMNodeModel struct {

--- a/internal/services/cluster/model.go
+++ b/internal/services/cluster/model.go
@@ -22,10 +22,10 @@ type TrustProviderModel struct {
 }
 
 type K8sPsatConfigModel struct {
-	Enabled                types.Bool           `tfsdk:"enabled"`
+	Enabled                types.Bool            `tfsdk:"enabled"`
 	AllowedServiceAccounts []ServiceAccountModel `tfsdk:"allowed_service_accounts"`
-	AllowedNodeLabelKeys   []types.String        `tfsdk:"allowed_node_label_keys"`
-	AllowedPodLabelKeys    []types.String        `tfsdk:"allowed_pod_label_keys"`
+	AllowedNodeLabelKeys   types.List            `tfsdk:"allowed_node_label_keys"`
+	AllowedPodLabelKeys    types.List            `tfsdk:"allowed_pod_label_keys"`
 	ApiServerCaCert        types.String          `tfsdk:"api_server_ca_cert"`
 	ApiServerURL           types.String          `tfsdk:"api_server_url"`
 	ApiServerTLSServerName types.String          `tfsdk:"api_server_tls_server_name"`

--- a/internal/services/cluster/resource.go
+++ b/internal/services/cluster/resource.go
@@ -10,6 +10,7 @@ import (
 	trustproviderpb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_provider/v1alpha1"
 	sdkclient "github.com/cofide/cofide-api-sdk/pkg/connect/client"
 	"github.com/cofide/terraform-provider-cofide/internal/util"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	tftypes "github.com/hashicorp/terraform-plugin-framework/types"
@@ -90,7 +91,7 @@ func (c *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 		cluster.OidcIssuerCaCert = decodedCert
 	}
 
-	trustProvider, err := trustProviderToProto(plan.TrustProvider)
+	trustProvider, err := trustProviderToProto(ctx, plan.TrustProvider)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating trust provider",
@@ -266,14 +267,14 @@ func (c *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if plan.TrustProvider != nil && !plan.TrustProvider.Kind.IsNull() {
-		trustProvider, err := trustProviderToProto(plan.TrustProvider)
+		trustProvider, err := trustProviderToProto(ctx, plan.TrustProvider)
 		if err != nil {
 			resp.Diagnostics.AddError("Error updating trust provider", fmt.Sprintf("Failed to create trust provider: %s", err))
 			return
 		}
 		cluster.TrustProvider = trustProvider
 	} else {
-		trustProvider, _ := trustProviderToProto(state.TrustProvider)
+		trustProvider, _ := trustProviderToProto(ctx, state.TrustProvider)
 		cluster.TrustProvider = trustProvider
 	}
 
@@ -377,13 +378,13 @@ func newTrustProvider(kind string) (*trustproviderpb.TrustProvider, error) {
 }
 
 // trustProviderToProto converts a TrustProviderModel to a TrustProvider proto message.
-func trustProviderToProto(model *TrustProviderModel) (*trustproviderpb.TrustProvider, error) {
+func trustProviderToProto(ctx context.Context, model *TrustProviderModel) (*trustproviderpb.TrustProvider, error) {
 	tp, err := newTrustProvider(model.Kind.ValueString())
 	if err != nil {
 		return nil, err
 	}
 	if model.K8sPsatConfig != nil {
-		cfg, err := k8sPsatConfigToProto(model.K8sPsatConfig)
+		cfg, err := k8sPsatConfigToProto(ctx, model.K8sPsatConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +394,7 @@ func trustProviderToProto(model *TrustProviderModel) (*trustproviderpb.TrustProv
 }
 
 // k8sPsatConfigToProto converts a K8sPsatConfigModel to a K8SPsatConfig proto message.
-func k8sPsatConfigToProto(model *K8sPsatConfigModel) (*trustproviderpb.K8SPsatConfig, error) {
+func k8sPsatConfigToProto(ctx context.Context, model *K8sPsatConfigModel) (*trustproviderpb.K8SPsatConfig, error) {
 	cfg := &trustproviderpb.K8SPsatConfig{
 		Enabled: model.Enabled.ValueBool(),
 	}
@@ -405,13 +406,17 @@ func k8sPsatConfigToProto(model *K8sPsatConfigModel) (*trustproviderpb.K8SPsatCo
 		})
 	}
 
-	for _, key := range model.AllowedNodeLabelKeys {
-		cfg.AllowedNodeLabelKeys = append(cfg.AllowedNodeLabelKeys, key.ValueString())
+	var allowedNodeLabelKeys []string
+	if diags := model.AllowedNodeLabelKeys.ElementsAs(ctx, &allowedNodeLabelKeys, false); diags.HasError() {
+		return nil, fmt.Errorf("error reading allowed_node_label_keys")
 	}
+	cfg.AllowedNodeLabelKeys = allowedNodeLabelKeys
 
-	for _, key := range model.AllowedPodLabelKeys {
-		cfg.AllowedPodLabelKeys = append(cfg.AllowedPodLabelKeys, key.ValueString())
+	var allowedPodLabelKeys []string
+	if diags := model.AllowedPodLabelKeys.ElementsAs(ctx, &allowedPodLabelKeys, false); diags.HasError() {
+		return nil, fmt.Errorf("error reading allowed_pod_label_keys")
 	}
+	cfg.AllowedPodLabelKeys = allowedPodLabelKeys
 
 	if !model.ApiServerCaCert.IsNull() && model.ApiServerCaCert.ValueString() != "" {
 		decoded, err := base64.StdEncoding.DecodeString(model.ApiServerCaCert.ValueString())
@@ -456,10 +461,10 @@ func k8sPsatConfigForState(model, prev *K8sPsatConfigModel) *K8sPsatConfigModel 
 	if len(model.AllowedServiceAccounts) == 0 && len(prev.AllowedServiceAccounts) == 0 && prev.AllowedServiceAccounts != nil {
 		model.AllowedServiceAccounts = prev.AllowedServiceAccounts
 	}
-	if len(model.AllowedNodeLabelKeys) == 0 && len(prev.AllowedNodeLabelKeys) == 0 && prev.AllowedNodeLabelKeys != nil {
+	if model.AllowedNodeLabelKeys.IsNull() && !prev.AllowedNodeLabelKeys.IsNull() && len(prev.AllowedNodeLabelKeys.Elements()) == 0 {
 		model.AllowedNodeLabelKeys = prev.AllowedNodeLabelKeys
 	}
-	if len(model.AllowedPodLabelKeys) == 0 && len(prev.AllowedPodLabelKeys) == 0 && prev.AllowedPodLabelKeys != nil {
+	if model.AllowedPodLabelKeys.IsNull() && !prev.AllowedPodLabelKeys.IsNull() && len(prev.AllowedPodLabelKeys.Elements()) == 0 {
 		model.AllowedPodLabelKeys = prev.AllowedPodLabelKeys
 	}
 	return model
@@ -489,12 +494,24 @@ func k8sPsatConfigFromProto(cfg *trustproviderpb.K8SPsatConfig) *K8sPsatConfigMo
 		})
 	}
 
-	for _, key := range cfg.AllowedNodeLabelKeys {
-		model.AllowedNodeLabelKeys = append(model.AllowedNodeLabelKeys, tftypes.StringValue(key))
+	if len(cfg.AllowedNodeLabelKeys) > 0 {
+		nodeLabelKeyElems := make([]attr.Value, 0, len(cfg.AllowedNodeLabelKeys))
+		for _, key := range cfg.AllowedNodeLabelKeys {
+			nodeLabelKeyElems = append(nodeLabelKeyElems, tftypes.StringValue(key))
+		}
+		model.AllowedNodeLabelKeys = tftypes.ListValueMust(tftypes.StringType, nodeLabelKeyElems)
+	} else {
+		model.AllowedNodeLabelKeys = tftypes.ListNull(tftypes.StringType)
 	}
 
-	for _, key := range cfg.AllowedPodLabelKeys {
-		model.AllowedPodLabelKeys = append(model.AllowedPodLabelKeys, tftypes.StringValue(key))
+	if len(cfg.AllowedPodLabelKeys) > 0 {
+		podLabelKeyElems := make([]attr.Value, 0, len(cfg.AllowedPodLabelKeys))
+		for _, key := range cfg.AllowedPodLabelKeys {
+			podLabelKeyElems = append(podLabelKeyElems, tftypes.StringValue(key))
+		}
+		model.AllowedPodLabelKeys = tftypes.ListValueMust(tftypes.StringType, podLabelKeyElems)
+	} else {
+		model.AllowedPodLabelKeys = tftypes.ListNull(tftypes.StringType)
 	}
 
 	if len(cfg.ApiServerCaCert) > 0 {

--- a/internal/services/cluster/resource.go
+++ b/internal/services/cluster/resource.go
@@ -408,13 +408,13 @@ func k8sPsatConfigToProto(ctx context.Context, model *K8sPsatConfigModel) (*trus
 
 	var allowedNodeLabelKeys []string
 	if diags := model.AllowedNodeLabelKeys.ElementsAs(ctx, &allowedNodeLabelKeys, false); diags.HasError() {
-		return nil, fmt.Errorf("error reading allowed_node_label_keys")
+		return nil, fmt.Errorf("error reading allowed_node_label_keys: %s", diags[0].Detail())
 	}
 	cfg.AllowedNodeLabelKeys = allowedNodeLabelKeys
 
 	var allowedPodLabelKeys []string
 	if diags := model.AllowedPodLabelKeys.ElementsAs(ctx, &allowedPodLabelKeys, false); diags.HasError() {
-		return nil, fmt.Errorf("error reading allowed_pod_label_keys")
+		return nil, fmt.Errorf("error reading allowed_pod_label_keys: %s", diags[0].Detail())
 	}
 	cfg.AllowedPodLabelKeys = allowedPodLabelKeys
 

--- a/internal/services/cluster/resource_test.go
+++ b/internal/services/cluster/resource_test.go
@@ -1,8 +1,10 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -257,8 +259,8 @@ func TestTrustProviderRoundTrip(t *testing.T) {
 				K8sPsatConfig: &K8sPsatConfigModel{
 					Enabled:                types.BoolValue(false),
 					AllowedServiceAccounts: nil,
-					AllowedNodeLabelKeys:   nil,
-					AllowedPodLabelKeys:    nil,
+					AllowedNodeLabelKeys:   types.ListNull(types.StringType),
+					AllowedPodLabelKeys:    types.ListNull(types.StringType),
 					ApiServerCaCert:        types.StringNull(),
 					ApiServerURL:           types.StringNull(),
 					ApiServerTLSServerName: types.StringNull(),
@@ -274,8 +276,8 @@ func TestTrustProviderRoundTrip(t *testing.T) {
 				K8sPsatConfig: &K8sPsatConfigModel{
 					Enabled:                types.BoolValue(true),
 					AllowedServiceAccounts: nil,
-					AllowedNodeLabelKeys:   nil,
-					AllowedPodLabelKeys:    nil,
+					AllowedNodeLabelKeys:   types.ListNull(types.StringType),
+					AllowedPodLabelKeys:    types.ListNull(types.StringType),
 					ApiServerCaCert:        types.StringNull(),
 					ApiServerURL:           types.StringNull(),
 					ApiServerTLSServerName: types.StringNull(),
@@ -300,8 +302,8 @@ func TestTrustProviderRoundTrip(t *testing.T) {
 							ServiceAccountName: types.StringValue("app-agent"),
 						},
 					},
-					AllowedNodeLabelKeys:   []types.String{types.StringValue("kubernetes.io/hostname")},
-					AllowedPodLabelKeys:    []types.String{types.StringValue("app"), types.StringValue("version")},
+					AllowedNodeLabelKeys:   types.ListValueMust(types.StringType, []attr.Value{types.StringValue("kubernetes.io/hostname")}),
+					AllowedPodLabelKeys:    types.ListValueMust(types.StringType, []attr.Value{types.StringValue("app"), types.StringValue("version")}),
 					ApiServerCaCert:        types.StringValue("dGVzdC1jYQ=="), // base64("test-ca")
 					ApiServerURL:           types.StringValue("https://kubernetes.default.svc"),
 					ApiServerTLSServerName: types.StringValue("kubernetes"),
@@ -314,7 +316,7 @@ func TestTrustProviderRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			proto, err := trustProviderToProto(tt.model)
+			proto, err := trustProviderToProto(context.Background(), tt.model)
 			require.NoError(t, err)
 
 			got := trustProviderFromProto(proto)
@@ -334,16 +336,18 @@ func TestTrustProviderToProto_InvalidKind(t *testing.T) {
 		Kind:          types.StringValue("invalid"),
 		K8sPsatConfig: nil,
 	}
-	_, err := trustProviderToProto(model)
+	_, err := trustProviderToProto(context.Background(), model)
 	require.ErrorContains(t, err, "invalid trust provider kind: invalid")
 }
 
 func TestK8sPsatConfigToProto_InvalidBase64CaCert(t *testing.T) {
 	model := &K8sPsatConfigModel{
-		Enabled:         types.BoolValue(true),
-		ApiServerCaCert: types.StringValue("not-valid-base64!!!"),
+		Enabled:              types.BoolValue(true),
+		AllowedNodeLabelKeys: types.ListNull(types.StringType),
+		AllowedPodLabelKeys:  types.ListNull(types.StringType),
+		ApiServerCaCert:      types.StringValue("not-valid-base64!!!"),
 	}
-	_, err := k8sPsatConfigToProto(model)
+	_, err := k8sPsatConfigToProto(context.Background(), model)
 	require.ErrorContains(t, err, "failed to decode api_server_ca_cert from base64")
 }
 
@@ -386,33 +390,33 @@ func TestK8sPsatConfigForState(t *testing.T) {
 		},
 		{
 			name:  "nil API node label keys, nil prev → nil",
-			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: nil},
-			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: nil},
-			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: nil},
+			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListNull(types.StringType)},
+			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListNull(types.StringType)},
+			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListNull(types.StringType)},
 		},
 		{
 			name:  "nil API node label keys, empty prev → empty preserved",
-			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: nil},
-			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: []types.String{}},
-			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: []types.String{}},
+			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListNull(types.StringType)},
+			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListValueMust(types.StringType, []attr.Value{})},
+			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListValueMust(types.StringType, []attr.Value{})},
 		},
 		{
 			name:  "nil API pod label keys, empty prev → empty preserved",
-			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: nil},
-			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: []types.String{}},
-			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: []types.String{}},
+			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: types.ListNull(types.StringType)},
+			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: types.ListValueMust(types.StringType, []attr.Value{})},
+			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: types.ListValueMust(types.StringType, []attr.Value{})},
 		},
 		{
 			name:  "nil API node label keys, non-empty prev → nil (API removal wins)",
-			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: nil},
-			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: []types.String{types.StringValue("kubernetes.io/hostname")}},
-			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: nil},
+			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListNull(types.StringType)},
+			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("kubernetes.io/hostname")})},
+			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedNodeLabelKeys: types.ListNull(types.StringType)},
 		},
 		{
 			name:  "nil API pod label keys, non-empty prev → nil (API removal wins)",
-			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: nil},
-			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: []types.String{types.StringValue("app")}},
-			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: nil},
+			model: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: types.ListNull(types.StringType)},
+			prev:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("app")})},
+			want:  &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedPodLabelKeys: types.ListNull(types.StringType)},
 		},
 	}
 
@@ -434,28 +438,44 @@ func TestTrustProviderForState(t *testing.T) {
 		{
 			name: "nil prev → model returned as-is",
 			model: &TrustProviderModel{
-				Kind:          types.StringValue("kubernetes"),
-				K8sPsatConfig: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedServiceAccounts: nil},
+				Kind: types.StringValue("kubernetes"),
+				K8sPsatConfig: &K8sPsatConfigModel{
+					Enabled:              types.BoolValue(true),
+					AllowedNodeLabelKeys: types.ListNull(types.StringType),
+					AllowedPodLabelKeys:  types.ListNull(types.StringType),
+				},
 			},
 			prev: nil,
 			want: &TrustProviderModel{
-				Kind:          types.StringValue("kubernetes"),
-				K8sPsatConfig: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedServiceAccounts: nil},
+				Kind: types.StringValue("kubernetes"),
+				K8sPsatConfig: &K8sPsatConfigModel{
+					Enabled:              types.BoolValue(true),
+					AllowedNodeLabelKeys: types.ListNull(types.StringType),
+					AllowedPodLabelKeys:  types.ListNull(types.StringType),
+				},
 			},
 		},
 		{
 			name: "nil prev k8s_psat_config → model returned as-is",
 			model: &TrustProviderModel{
-				Kind:          types.StringValue("kubernetes"),
-				K8sPsatConfig: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedServiceAccounts: nil},
+				Kind: types.StringValue("kubernetes"),
+				K8sPsatConfig: &K8sPsatConfigModel{
+					Enabled:              types.BoolValue(true),
+					AllowedNodeLabelKeys: types.ListNull(types.StringType),
+					AllowedPodLabelKeys:  types.ListNull(types.StringType),
+				},
 			},
 			prev: &TrustProviderModel{
 				Kind:          types.StringValue("kubernetes"),
 				K8sPsatConfig: nil,
 			},
 			want: &TrustProviderModel{
-				Kind:          types.StringValue("kubernetes"),
-				K8sPsatConfig: &K8sPsatConfigModel{Enabled: types.BoolValue(true), AllowedServiceAccounts: nil},
+				Kind: types.StringValue("kubernetes"),
+				K8sPsatConfig: &K8sPsatConfigModel{
+					Enabled:              types.BoolValue(true),
+					AllowedNodeLabelKeys: types.ListNull(types.StringType),
+					AllowedPodLabelKeys:  types.ListNull(types.StringType),
+				},
 			},
 		},
 		{
@@ -480,8 +500,8 @@ func TestTrustProviderForState(t *testing.T) {
 				K8sPsatConfig: &K8sPsatConfigModel{
 					Enabled:                types.BoolValue(true),
 					AllowedServiceAccounts: nil,
-					AllowedNodeLabelKeys:   nil,
-					AllowedPodLabelKeys:    nil,
+					AllowedNodeLabelKeys:   types.ListNull(types.StringType),
+					AllowedPodLabelKeys:    types.ListNull(types.StringType),
 				},
 			},
 			prev: &TrustProviderModel{
@@ -489,8 +509,8 @@ func TestTrustProviderForState(t *testing.T) {
 				K8sPsatConfig: &K8sPsatConfigModel{
 					Enabled:                types.BoolValue(true),
 					AllowedServiceAccounts: []ServiceAccountModel{},
-					AllowedNodeLabelKeys:   []types.String{},
-					AllowedPodLabelKeys:    nil,
+					AllowedNodeLabelKeys:   types.ListValueMust(types.StringType, []attr.Value{}),
+					AllowedPodLabelKeys:    types.ListNull(types.StringType),
 				},
 			},
 			want: &TrustProviderModel{
@@ -498,8 +518,8 @@ func TestTrustProviderForState(t *testing.T) {
 				K8sPsatConfig: &K8sPsatConfigModel{
 					Enabled:                types.BoolValue(true),
 					AllowedServiceAccounts: []ServiceAccountModel{},
-					AllowedNodeLabelKeys:   []types.String{},
-					AllowedPodLabelKeys:    nil,
+					AllowedNodeLabelKeys:   types.ListValueMust(types.StringType, []attr.Value{}),
+					AllowedPodLabelKeys:    types.ListNull(types.StringType),
 				},
 			},
 		},
@@ -509,7 +529,7 @@ func TestTrustProviderForState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Build a proto from the model, then call trustProviderForState with the prev.
 			// This exercises the full path including trustProviderFromProto.
-			proto, err := trustProviderToProto(tt.model)
+			proto, err := trustProviderToProto(context.Background(), tt.model)
 			require.NoError(t, err)
 			got := trustProviderForState(proto, tt.prev)
 			assert.Equal(t, tt.want, got)

--- a/internal/services/trustzoneserver/model.go
+++ b/internal/services/trustzoneserver/model.go
@@ -20,8 +20,8 @@ type TrustZoneServerStatusModel struct {
 }
 
 type ConnectK8sPsatConfigModel struct {
-	Audiences               []types.String `tfsdk:"audiences"`
-	SpireServerSpiffeIDPath types.String   `tfsdk:"spire_server_spiffe_id_path"`
+	Audiences               types.List   `tfsdk:"audiences"`
+	SpireServerSpiffeIDPath types.String `tfsdk:"spire_server_spiffe_id_path"`
 }
 
 type TrustZoneServersDataSourceModel struct {

--- a/internal/services/trustzoneserver/resource.go
+++ b/internal/services/trustzoneserver/resource.go
@@ -92,7 +92,12 @@ func (r *TrustZoneServerResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	if plan.ConnectK8sPsatConfig != nil {
-		server.ConnectK8SPsatConfig = connectK8sPsatConfigToProto(plan.ConnectK8sPsatConfig)
+		cfg, cfgDiags := connectK8sPsatConfigToProto(ctx, plan.ConnectK8sPsatConfig)
+		resp.Diagnostics.Append(cfgDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		server.ConnectK8SPsatConfig = cfg
 	}
 
 	createResp, err := r.client.TrustZoneServerV1Alpha1().CreateTrustZoneServer(ctx, server)
@@ -183,7 +188,12 @@ func (r *TrustZoneServerResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	if plan.ConnectK8sPsatConfig != nil {
-		server.ConnectK8SPsatConfig = connectK8sPsatConfigToProto(plan.ConnectK8sPsatConfig)
+		cfg, cfgDiags := connectK8sPsatConfigToProto(ctx, plan.ConnectK8sPsatConfig)
+		resp.Diagnostics.Append(cfgDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		server.ConnectK8SPsatConfig = cfg
 	}
 
 	updateMask := &trustzoneserversvcpb.UpdateTrustZoneServerRequest_UpdateMask{
@@ -294,25 +304,26 @@ func statusFromProto(s *trustzoneserverpb.TrustZoneServer_Status) (tftypes.Objec
 }
 
 // connectK8sPsatConfigToProto converts a ConnectK8sPsatConfigModel to a ConnectK8SPsatConfig proto.
-func connectK8sPsatConfigToProto(model *ConnectK8sPsatConfigModel) *trustzoneserverpb.ConnectK8SPsatConfig {
+func connectK8sPsatConfigToProto(ctx context.Context, model *ConnectK8sPsatConfigModel) (*trustzoneserverpb.ConnectK8SPsatConfig, diag.Diagnostics) {
 	cfg := &trustzoneserverpb.ConnectK8SPsatConfig{
 		SpireServerSpiffeIdPath: model.SpireServerSpiffeIDPath.ValueString(),
 	}
-	for _, a := range model.Audiences {
-		cfg.Audiences = append(cfg.Audiences, a.ValueString())
-	}
-	return cfg
+	var audiences []string
+	diags := model.Audiences.ElementsAs(ctx, &audiences, false)
+	cfg.Audiences = audiences
+	return cfg, diags
 }
 
 // connectK8sPsatConfigFromProto converts a ConnectK8SPsatConfig proto to a ConnectK8sPsatConfigModel.
 func connectK8sPsatConfigFromProto(cfg *trustzoneserverpb.ConnectK8SPsatConfig) *ConnectK8sPsatConfigModel {
-	model := &ConnectK8sPsatConfigModel{
-		SpireServerSpiffeIDPath: tftypes.StringValue(cfg.GetSpireServerSpiffeIdPath()),
-	}
+	elems := make([]attr.Value, 0, len(cfg.GetAudiences()))
 	for _, a := range cfg.GetAudiences() {
-		model.Audiences = append(model.Audiences, tftypes.StringValue(a))
+		elems = append(elems, tftypes.StringValue(a))
 	}
-	return model
+	return &ConnectK8sPsatConfigModel{
+		SpireServerSpiffeIDPath: tftypes.StringValue(cfg.GetSpireServerSpiffeIdPath()),
+		Audiences:               tftypes.ListValueMust(tftypes.StringType, elems),
+	}
 }
 
 // parseHelmValues parses the helm_values field from a YAML/JSON string to a structpb.Struct.


### PR DESCRIPTION
Similar to 260a6012ca81e1abd2645f7581b4da9e9abf69f9.

The framework cannot convert an unknown value into a Go slice ([]types.String),
so model fields using a list of strings must be types.List. Update
modelToProto to use ElementsAs and protoToModel to construct a
ListValue.

Related: #113

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
