### PR TITLE
Support svidstore

### DIFF
--- a/docs/resources/connect_attestation_policy.md
+++ b/docs/resources/connect_attestation_policy.md
@@ -257,6 +257,7 @@ Required:
 Optional:
 
 - `dns_names` (List of String) The list of DNS names for the static attestation policy.
+- `store_svid` (Boolean) When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if the svidstore agent plugin is enabled). Defaults to false.
 
 <a id="nestedatt--static--selectors"></a>
 ### Nested Schema for `static.selectors`

--- a/docs/resources/connect_attestation_policy.md
+++ b/docs/resources/connect_attestation_policy.md
@@ -257,7 +257,7 @@ Required:
 Optional:
 
 - `dns_names` (List of String) The list of DNS names for the static attestation policy.
-- `store_svid` (Boolean) When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if the svidstore agent plugin is enabled). Defaults to false.
+- `store_svid` (Boolean) When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if an svidstore agent plugin is enabled). Defaults to false.
 
 <a id="nestedatt--static--selectors"></a>
 ### Nested Schema for `static.selectors`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cofide/terraform-provider-cofide
 go 1.25.11
 
 require (
-	github.com/cofide/cofide-api-sdk v0.56.1
+	github.com/cofide/cofide-api-sdk v0.57.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cofide/cofide-api-sdk v0.56.1 h1:nGQ7g35Xm6hmyb7EAE3lBNTbcyPBlJ1ZkHsSovKW+Yg=
-github.com/cofide/cofide-api-sdk v0.56.1/go.mod h1:yhqW0wzz3IdZJDr76NTM8imA3LBDbc1V1AYoOxLHtuQ=
+github.com/cofide/cofide-api-sdk v0.57.0 h1:AB7CfRSQ5uXaeiqsA4BWqo/SyUWojYkoAXTTbpAAn2E=
+github.com/cofide/cofide-api-sdk v0.57.0/go.mod h1:yhqW0wzz3IdZJDr76NTM8imA3LBDbc1V1AYoOxLHtuQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=

--- a/internal/services/attestationpolicy/convert.go
+++ b/internal/services/attestationpolicy/convert.go
@@ -43,6 +43,7 @@ func modelToProto(ctx context.Context, model AttestationPolicyModel) (*attestati
 			ParentIdPath: model.Static.ParentIdPath.ValueStringPointer(),
 			Selectors:    convertSelectors(model.Static.Selectors),
 			DnsNames:     dnsNames,
+			StoreSvid:    !model.Static.StoreSvid.IsNull() && !model.Static.StoreSvid.IsUnknown() && model.Static.StoreSvid.ValueBool(),
 		}
 		proto.Policy = &attestationpolicypb.AttestationPolicy_Static{
 			Static: staticPolicy,
@@ -89,6 +90,7 @@ func protoToModel(proto *attestationpolicypb.AttestationPolicy) AttestationPolic
 			ParentIdPath: optionalStringValue(static.ParentIdPath),
 			Selectors:    convertProtoSelectors(static.GetSelectors()),
 			DNSNames:     convertProtoSelectorValues(static.GetDnsNames()),
+			StoreSvid:    tftypes.BoolValue(static.GetStoreSvid()),
 		}
 	}
 

--- a/internal/services/attestationpolicy/model.go
+++ b/internal/services/attestationpolicy/model.go
@@ -34,6 +34,7 @@ type APStaticModel struct {
 	ParentIdPath tftypes.String `tfsdk:"parent_id_path"`
 	Selectors    tftypes.List   `tfsdk:"selectors"`
 	DNSNames     tftypes.List   `tfsdk:"dns_names"`
+	StoreSvid    tftypes.Bool   `tfsdk:"store_svid"`
 }
 
 type APTPMNodeModel struct {

--- a/internal/services/attestationpolicy/schema.go
+++ b/internal/services/attestationpolicy/schema.go
@@ -148,6 +148,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Optional:    true,
 						ElementType: tftypes.StringType,
 					},
+					"store_svid": schema.BoolAttribute{
+						Description: "When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if the svidstore agent plugin is enabled). Defaults to false.",
+						Optional:    true,
+						Computed:    true,
+					},
 				},
 			},
 			"tpm_node": schema.SingleNestedAttribute{

--- a/internal/services/attestationpolicy/schema.go
+++ b/internal/services/attestationpolicy/schema.go
@@ -149,7 +149,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						ElementType: tftypes.StringType,
 					},
 					"store_svid": schema.BoolAttribute{
-						Description: "When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if the svidstore agent plugin is enabled). Defaults to false.",
+						Description: "When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if an svidstore agent plugin is enabled). Defaults to false.",
 						Optional:    true,
 						Computed:    true,
 					},


### PR DESCRIPTION
Part of https://github.com/cofide/cofide-connect/issues/1976

Depends on https://github.com/cofide/cofide-api-sdk/pull/209 and https://github.com/cofide/cofide-connect/pull/1986

Adds support for specifying via the terraform provider that the identity created by a static attestation policy should be stored by SPIRE agents in an svidstore.