### PR TITLE
Allow updating attestation policies without user specifying org ID

### DIFF
--- a/internal/services/attestationpolicy/resource.go
+++ b/internal/services/attestationpolicy/resource.go
@@ -128,6 +128,12 @@ func (r *AttestationPolicyResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 	policy.Id = &policyID
+	if (policy.OrgId == nil || *policy.OrgId == "") && !state.OrgID.IsNull() && !state.OrgID.IsUnknown() {
+		orgID := state.OrgID.ValueString()
+		if orgID != "" {
+			policy.OrgId = &orgID
+		}
+	}
 
 	updateResp, err := r.client.AttestationPolicyV1Alpha1().UpdateAttestationPolicy(ctx, policy)
 	if err != nil {


### PR DESCRIPTION
The org ID on an attestation policy is derived on create if not set (set to the default org).

But updating the attestation policy fails if the org ID isn't set explicitly by the user - this fixes that by loading from the state if not set explicitly by the user.