### PR TITLE
Add subject_audience field to exchange policy

### DIFF
--- a/docs/data-sources/connect_exchange_policies.md
+++ b/docs/data-sources/connect_exchange_policies.md
@@ -69,6 +69,7 @@ Read-Only:
 - `name` (String) The name of the exchange policy.
 - `org_id` (String) The ID of the organization.
 - `outbound_scopes` (List of String) Outbound scopes to grant.
+- `subject_audience` (Attributes List) Match conditions on the audience claim of the inbound subject token. (see [below for nested schema](#nestedatt--exchange_policies--subject_audience))
 - `subject_identity` (Attributes List) Match conditions on the subject identity of the inbound token. (see [below for nested schema](#nestedatt--exchange_policies--subject_identity))
 - `subject_issuer` (Attributes List) Match conditions on the issuer of the inbound subject token. (see [below for nested schema](#nestedatt--exchange_policies--subject_issuer))
 - `target_audience` (Attributes List) Match conditions on the requested target audience. (see [below for nested schema](#nestedatt--exchange_policies--target_audience))
@@ -94,6 +95,15 @@ Read-Only:
 
 <a id="nestedatt--exchange_policies--client_id"></a>
 ### Nested Schema for `exchange_policies.client_id`
+
+Read-Only:
+
+- `exact` (String) Exact string match.
+- `glob` (String) Glob pattern match.
+
+
+<a id="nestedatt--exchange_policies--subject_audience"></a>
+### Nested Schema for `exchange_policies.subject_audience`
 
 Read-Only:
 

--- a/docs/data-sources/connect_exchange_policy.md
+++ b/docs/data-sources/connect_exchange_policy.md
@@ -59,6 +59,7 @@ output "exchange_policy_id" {
 - `name` (String) The name of the exchange policy.
 - `org_id` (String) The ID of the organization.
 - `outbound_scopes` (List of String) Outbound scopes to grant.
+- `subject_audience` (Attributes List) Match conditions on the audience claim of the inbound subject token. (see [below for nested schema](#nestedatt--subject_audience))
 - `subject_identity` (Attributes List) Match conditions on the subject identity of the inbound token. (see [below for nested schema](#nestedatt--subject_identity))
 - `subject_issuer` (Attributes List) Match conditions on the issuer of the inbound subject token. (see [below for nested schema](#nestedatt--subject_issuer))
 - `target_audience` (Attributes List) Match conditions on the requested target audience. (see [below for nested schema](#nestedatt--target_audience))
@@ -84,6 +85,15 @@ Read-Only:
 
 <a id="nestedatt--client_id"></a>
 ### Nested Schema for `client_id`
+
+Read-Only:
+
+- `exact` (String) Exact string match.
+- `glob` (String) Glob pattern match.
+
+
+<a id="nestedatt--subject_audience"></a>
+### Nested Schema for `subject_audience`
 
 Read-Only:
 

--- a/docs/resources/connect_exchange_policy.md
+++ b/docs/resources/connect_exchange_policy.md
@@ -49,6 +49,10 @@ resource "cofide_connect_exchange_policy" "example" {
     { glob = "spiffe://example.org/ns/bar/sa/*" }
   ]
 
+  subject_audience = [
+    { exact = "https://audience.ep-tz.cofide.dev" }
+  ]
+
   target_audience = [
     { exact = "https://api.example.org" }
   ]
@@ -121,6 +125,7 @@ output "exchange_policy_id" {
 - `actor_issuer` (Attributes List) Match conditions on the issuer of the inbound actor token. (see [below for nested schema](#nestedatt--actor_issuer))
 - `client_id` (Attributes List) Match conditions on the OAuth client_id presenting the exchange request. (see [below for nested schema](#nestedatt--client_id))
 - `outbound_scopes` (List of String) Outbound scopes to grant. Only relevant when action is allow.
+- `subject_audience` (Attributes List) Match conditions on the audience claim of the inbound subject token. (see [below for nested schema](#nestedatt--subject_audience))
 - `subject_identity` (Attributes List) Match conditions on the subject identity of the inbound token. (see [below for nested schema](#nestedatt--subject_identity))
 - `subject_issuer` (Attributes List) Match conditions on the issuer of the inbound subject token. (see [below for nested schema](#nestedatt--subject_issuer))
 - `target_audience` (Attributes List) Match conditions on the requested target audience. (see [below for nested schema](#nestedatt--target_audience))
@@ -150,6 +155,15 @@ Optional:
 
 <a id="nestedatt--client_id"></a>
 ### Nested Schema for `client_id`
+
+Optional:
+
+- `exact` (String) Exact string match.
+- `glob` (String) Glob pattern match (e.g. `spiffe://trust.domain/ns/*/sa/*`).
+
+
+<a id="nestedatt--subject_audience"></a>
+### Nested Schema for `subject_audience`
 
 Optional:
 

--- a/examples/resources/cofide_connect_exchange_policy/allow/main.tf
+++ b/examples/resources/cofide_connect_exchange_policy/allow/main.tf
@@ -8,6 +8,10 @@ resource "cofide_connect_exchange_policy" "example" {
     { glob = "spiffe://example.org/ns/bar/sa/*" }
   ]
 
+  subject_audience = [
+    { exact = "https://audience.ep-tz.cofide.dev" }
+  ]
+
   target_audience = [
     { exact = "https://api.example.org" }
   ]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cofide/terraform-provider-cofide
 go 1.25.11
 
 require (
-	github.com/cofide/cofide-api-sdk v0.55.0
+	github.com/cofide/cofide-api-sdk v0.56.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cofide/cofide-api-sdk v0.55.0 h1:LrULi4I7bF50E9MwyMCz6Ry0n5sfjsioIcmF+FqlCG4=
-github.com/cofide/cofide-api-sdk v0.55.0/go.mod h1:7M0g5A4Qc5h4Y3dy833O7G3ldDbzNAYqR/hIrL1BT3k=
+github.com/cofide/cofide-api-sdk v0.56.1 h1:nGQ7g35Xm6hmyb7EAE3lBNTbcyPBlJ1ZkHsSovKW+Yg=
+github.com/cofide/cofide-api-sdk v0.56.1/go.mod h1:yhqW0wzz3IdZJDr76NTM8imA3LBDbc1V1AYoOxLHtuQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=

--- a/internal/services/exchangepolicy/convert.go
+++ b/internal/services/exchangepolicy/convert.go
@@ -48,6 +48,7 @@ func modelToProto(ctx context.Context, model ExchangePolicyModel) (*exchangepoli
 		{"subject_issuer", model.SubjectIssuer, &proto.SubjectIssuer},
 		{"actor_identity", model.ActorIdentity, &proto.ActorIdentity},
 		{"actor_issuer", model.ActorIssuer, &proto.ActorIssuer},
+		{"subject_audience", model.SubjectAudience, &proto.SubjectAudience},
 		{"client_id", model.ClientID, &proto.ClientId},
 		{"target_audience", model.TargetAudience, &proto.TargetAudience},
 	}
@@ -90,6 +91,7 @@ func protoToModel(proto *exchangepolicypb.ExchangePolicy) (ExchangePolicyModel, 
 		{"subject_issuer", proto.GetSubjectIssuer(), &model.SubjectIssuer},
 		{"actor_identity", proto.GetActorIdentity(), &model.ActorIdentity},
 		{"actor_issuer", proto.GetActorIssuer(), &model.ActorIssuer},
+		{"subject_audience", proto.GetSubjectAudience(), &model.SubjectAudience},
 		{"client_id", proto.GetClientId(), &model.ClientID},
 		{"target_audience", proto.GetTargetAudience(), &model.TargetAudience},
 	}

--- a/internal/services/exchangepolicy/convert_test.go
+++ b/internal/services/exchangepolicy/convert_test.go
@@ -31,6 +31,7 @@ func TestProtoToModel_Minimal(t *testing.T) {
 	assert.Equal(t, types.ListNull(stringMatcherObjectType), got.SubjectIssuer)
 	assert.Equal(t, types.ListNull(stringMatcherObjectType), got.ActorIdentity)
 	assert.Equal(t, types.ListNull(stringMatcherObjectType), got.ActorIssuer)
+	assert.Equal(t, types.ListNull(stringMatcherObjectType), got.SubjectAudience)
 	assert.Equal(t, types.ListNull(stringMatcherObjectType), got.ClientID)
 	assert.Equal(t, types.ListNull(stringMatcherObjectType), got.TargetAudience)
 	assert.Equal(t, types.ListValueMust(types.StringType, []attr.Value{}), got.OutboundScopes)
@@ -211,6 +212,7 @@ func TestRoundTrip(t *testing.T) {
 				SubjectIssuer:   nullMatchers,
 				ActorIdentity:   nullMatchers,
 				ActorIssuer:     nullMatchers,
+				SubjectAudience: nullMatchers,
 				ClientID:        nullMatchers,
 				TargetAudience:  nullMatchers,
 				OutboundScopes:  types.ListValueMust(types.StringType, []attr.Value{}),
@@ -248,6 +250,12 @@ func TestRoundTrip(t *testing.T) {
 						"glob":  types.StringValue("spiffe://issuer.example.org/*"),
 					}),
 				}),
+				SubjectAudience: types.ListValueMust(stringMatcherObjectType, []attr.Value{
+					types.ObjectValueMust(stringMatcherAttrTypes, map[string]attr.Value{
+						"exact": types.StringValue("https://audience.example.org"),
+						"glob":  types.StringNull(),
+					}),
+				}),
 				ClientID: types.ListValueMust(stringMatcherObjectType, []attr.Value{
 					types.ObjectValueMust(stringMatcherAttrTypes, map[string]attr.Value{
 						"exact": types.StringValue("my-client"),
@@ -278,6 +286,7 @@ func TestRoundTrip(t *testing.T) {
 				SubjectIssuer:   nullMatchers,
 				ActorIdentity:   nullMatchers,
 				ActorIssuer:     nullMatchers,
+				SubjectAudience: nullMatchers,
 				ClientID:        nullMatchers,
 				TargetAudience:  nullMatchers,
 				OutboundScopes:  types.ListValueMust(types.StringType, []attr.Value{}),
@@ -308,6 +317,7 @@ func TestRoundTrip(t *testing.T) {
 				SubjectIssuer:  nullMatchers,
 				ActorIdentity:  nullMatchers,
 				ActorIssuer:    nullMatchers,
+				SubjectAudience: nullMatchers,
 				ClientID:       nullMatchers,
 				TargetAudience: nullMatchers,
 				OutboundScopes: types.ListValueMust(types.StringType, []attr.Value{}),

--- a/internal/services/exchangepolicy/data_source_schema.go
+++ b/internal/services/exchangepolicy/data_source_schema.go
@@ -77,6 +77,7 @@ func exchangePolicyNestedAttributes() map[string]schema.Attribute {
 		"subject_issuer":   stringSetDataSourceAttribute("Match conditions on the issuer of the inbound subject token."),
 		"actor_identity":   stringSetDataSourceAttribute("Match conditions on the actor identity of the inbound token."),
 		"actor_issuer":     stringSetDataSourceAttribute("Match conditions on the issuer of the inbound actor token."),
+		"subject_audience": stringSetDataSourceAttribute("Match conditions on the audience claim of the inbound subject token."),
 		"client_id":        stringSetDataSourceAttribute("Match conditions on the OAuth client_id presenting the exchange request."),
 		"target_audience":  stringSetDataSourceAttribute("Match conditions on the requested target audience."),
 		"outbound_scopes": schema.ListAttribute{

--- a/internal/services/exchangepolicy/model.go
+++ b/internal/services/exchangepolicy/model.go
@@ -12,6 +12,7 @@ type ExchangePolicyModel struct {
 	SubjectIssuer   tftypes.List   `tfsdk:"subject_issuer"`
 	ActorIdentity   tftypes.List   `tfsdk:"actor_identity"`
 	ActorIssuer     tftypes.List   `tfsdk:"actor_issuer"`
+	SubjectAudience tftypes.List   `tfsdk:"subject_audience"`
 	ClientID        tftypes.List   `tfsdk:"client_id"`
 	TargetAudience  tftypes.List   `tfsdk:"target_audience"`
 	OutboundScopes  tftypes.List   `tfsdk:"outbound_scopes"`

--- a/internal/services/exchangepolicy/schema.go
+++ b/internal/services/exchangepolicy/schema.go
@@ -61,6 +61,7 @@ func resourceSchema() schema.Schema {
 			"subject_issuer":   stringSetResourceAttribute("Match conditions on the issuer of the inbound subject token."),
 			"actor_identity":   stringSetResourceAttribute("Match conditions on the actor identity of the inbound token."),
 			"actor_issuer":     stringSetResourceAttribute("Match conditions on the issuer of the inbound actor token."),
+			"subject_audience": stringSetResourceAttribute("Match conditions on the audience claim of the inbound subject token."),
 			"client_id":        stringSetResourceAttribute("Match conditions on the OAuth client_id presenting the exchange request."),
 			"target_audience":  stringSetResourceAttribute("Match conditions on the requested target audience."),
 			"outbound_scopes": schema.ListAttribute{

--- a/test/connect_exchange_policy/main.tf
+++ b/test/connect_exchange_policy/main.tf
@@ -18,6 +18,10 @@ resource "cofide_connect_exchange_policy" "allow_policy" {
     { glob = "spiffe://ep-tz.cofide.dev/ns/bar/sa/*" }
   ]
 
+  subject_audience = [
+    { exact = "https://audience.ep-tz.cofide.dev" }
+  ]
+
   target_audience = [
     { exact = "https://api.ep-tz.cofide.dev" }
   ]


### PR DESCRIPTION
Add support for the subject_audience StringSet field in the exchange
policy resource, data source, and conversion logic.
