### PR TITLE
fix: Make external_server and kubernetes_context optional

### DIFF
--- a/docs/resources/connect_cluster.md
+++ b/docs/resources/connect_cluster.md
@@ -152,8 +152,6 @@ output "cluster_id" {
 
 ### Required
 
-- `external_server` (Boolean) Whether the SPIRE server runs externally to this cluster. Set to `true` for clusters that delegate to a centralized SPIRE server.
-- `kubernetes_context` (String) The Kubernetes context of the cluster.
 - `name` (String) The name of the cluster.
 - `profile` (String) The Cofide profile used by the cluster (e.g. `kubernetes`, `istio`). Ensures Cofide SPIRE is configured correctly for the target environment.
 - `trust_provider` (Attributes) The trust provider of the cluster. (see [below for nested schema](#nestedatt--trust_provider))
@@ -161,7 +159,9 @@ output "cluster_id" {
 
 ### Optional
 
+- `external_server` (Boolean) Whether the SPIRE server runs externally to this cluster. Set to `true` for clusters that delegate to a centralized SPIRE server.
 - `extra_helm_values` (String) Additional Helm values for the Cofide SPIRE Helm chart installation, in YAML format. Use `yamlencode()` to generate from a Terraform map.
+- `kubernetes_context` (String) The Kubernetes context of the cluster.
 - `oidc_issuer_ca_cert` (String) The CA certificate (base64-encoded) to validate the cluster's OIDC issuer URL. Use `base64encode(file(...))` to supply a PEM certificate file.
 - `oidc_issuer_url` (String) The OIDC issuer URL of the cluster.
 - `org_id` (String) The ID of the organization.

--- a/internal/services/cluster/schema.go
+++ b/internal/services/cluster/schema.go
@@ -7,7 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -45,7 +47,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"kubernetes_context": schema.StringAttribute{
 				Description: "The Kubernetes context of the cluster.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"trust_provider": schema.SingleNestedAttribute{
 				Description: "The trust provider of the cluster.",
@@ -126,7 +130,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"external_server": schema.BoolAttribute{
 				Description: "Whether the SPIRE server runs externally to this cluster. Set to `true` for clusters that delegate to a centralized SPIRE server.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"oidc_issuer_url": schema.StringAttribute{
 				Description: "The OIDC issuer URL of the cluster.",


### PR DESCRIPTION
These fields have appropriate defaults (false and empty string) and so do not need to force the consumer to provide them.