### PR TITLE
Load credentials from same source as CLI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,6 @@ This project is the official Terraform provider for Cofide.
 
 ### Optional
 
-- `api_token` (String, Sensitive) API token used to communicate with the Cofide Connect API. Alternatively, can be configured using the `COFIDE_API_TOKEN` environment variable.
+- `api_token` (String, Sensitive) API token used to communicate with the Cofide Connect API. Can be configured via the `COFIDE_API_TOKEN` environment variable or read from `~/.cofide/credentials` (JSON key: `access_token`).
 - `connect_url` (String) Cofide Connect service URL. Alternatively, can be configured using the `COFIDE_CONNECT_URL` environment variable.
 - `insecure_skip_verify` (Boolean) Skip TLS certificate verification (should only be used for local testing). Alternatively, can be configured using the `COFIDE_INSECURE_SKIP_VERIFY` environment variable.

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -1,0 +1,34 @@
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type credentialsFile struct {
+	AccessToken string `json:"access_token"`
+}
+
+// LoadFromFile reads the API token from ~/.cofide/credentials.
+// Returns ("", nil) if the file does not exist.
+func LoadFromFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(home, ".cofide", "credentials")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	var cf credentialsFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return cf.AccessToken, nil
+}

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -1,0 +1,62 @@
+package credentials
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFromFile_validFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	credDir := filepath.Join(dir, ".cofide")
+	if err := os.MkdirAll(credDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, "credentials"), []byte(`{"access_token":"my-token"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := LoadFromFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "my-token" {
+		t.Fatalf("expected %q, got %q", "my-token", token)
+	}
+}
+
+func TestLoadFromFile_fileNotExist(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	token, err := LoadFromFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %q", token)
+	}
+}
+
+func TestLoadFromFile_invalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	credDir := filepath.Join(dir, ".cofide")
+	if err := os.MkdirAll(credDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, "credentials"), []byte(`not-json`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromFile()
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -17,6 +17,7 @@ import (
 	sdkclient "github.com/cofide/cofide-api-sdk/pkg/connect/client"
 	"github.com/cofide/terraform-provider-cofide/internal/client"
 	"github.com/cofide/terraform-provider-cofide/internal/consts"
+	"github.com/cofide/terraform-provider-cofide/internal/credentials"
 	"github.com/cofide/terraform-provider-cofide/internal/services/apbinding"
 	"github.com/cofide/terraform-provider-cofide/internal/services/attestationpolicy"
 	"github.com/cofide/terraform-provider-cofide/internal/services/cluster"
@@ -61,7 +62,7 @@ func (p *CofideProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 		Description: "This project is the official Terraform provider for Cofide.",
 		Attributes: map[string]schema.Attribute{
 			"api_token": schema.StringAttribute{
-				Description: fmt.Sprintf("API token used to communicate with the Cofide Connect API. Alternatively, can be configured using the `%s` environment variable.", consts.APITokenEnvVarKey),
+				Description: fmt.Sprintf("API token used to communicate with the Cofide Connect API. Can be configured via the `%s` environment variable or read from `~/.cofide/credentials` (JSON key: `access_token`).", consts.APITokenEnvVarKey),
 				Optional:    true,
 				Sensitive:   true,
 			},
@@ -96,6 +97,14 @@ func (p *CofideProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	if apiToken == "" {
 		apiToken = os.Getenv(consts.APITokenEnvVarKey)
 	}
+	if apiToken == "" {
+		token, err := credentials.LoadFromFile()
+		if err != nil {
+			tflog.Warn(ctx, "Failed to read credentials file", map[string]interface{}{"error": err.Error()})
+		} else {
+			apiToken = token
+		}
+	}
 
 	connectURL := config.ConnectURL.ValueString()
 	if connectURL == "" {
@@ -114,7 +123,7 @@ func (p *CofideProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	if apiToken == "" {
 		resp.Diagnostics.AddError(
 			"Missing API Token Configuration",
-			"API token must be specified either in provider configuration or via COFIDE_API_TOKEN environment variable",
+			"API token must be specified in provider configuration, via the COFIDE_API_TOKEN environment variable, or via the credentials file at ~/.cofide/credentials.",
 		)
 		return
 	}


### PR DESCRIPTION
CLI loads credentials from file (and generates this file). Using this same credential source simplifies the terraform provider usage as after logging in with the CLI users don't need to manually export the credentials into the environment.

Configuring credentials directly through the provider config still takes precedence, followed by the environment variable, then followed by the credentials file (the expected fallback chain from other providers, e.g. GCP and AWS).