### PR TITLE
Org ID on child resources is read only as it is derived by the server from the parent(s)

### DIFF
--- a/docs/resources/connect_ap_binding.md
+++ b/docs/resources/connect_ap_binding.md
@@ -126,11 +126,11 @@ output "ap_binding_id" {
 ### Optional
 
 - `federations` (List of Object) The federated trust zones which will be visible to workloads matching the policy in this binding. Each entry specifies the `trust_zone_id` of a federated trust zone. (see [below for nested schema](#nestedatt--federations))
-- `org_id` (String) The ID of the organization.
 
 ### Read-Only
 
 - `id` (String) The ID of the attestation policy binding.
+- `org_id` (String) The ID of the organization. Derived from the trust zone by Cofide Connect.
 
 <a id="nestedatt--federations"></a>
 ### Nested Schema for `federations`

--- a/docs/resources/connect_cluster.md
+++ b/docs/resources/connect_cluster.md
@@ -164,11 +164,11 @@ output "cluster_id" {
 - `kubernetes_context` (String) The Kubernetes context of the cluster.
 - `oidc_issuer_ca_cert` (String) The CA certificate (base64-encoded) to validate the cluster's OIDC issuer URL. Use `base64encode(file(...))` to supply a PEM certificate file.
 - `oidc_issuer_url` (String) The OIDC issuer URL of the cluster.
-- `org_id` (String) The ID of the organization.
 
 ### Read-Only
 
 - `id` (String) The ID of the cluster.
+- `org_id` (String) The ID of the organization. Derived from the trust zone by Cofide Connect.
 
 <a id="nestedatt--trust_provider"></a>
 ### Nested Schema for `trust_provider`

--- a/docs/resources/connect_federation.md
+++ b/docs/resources/connect_federation.md
@@ -66,10 +66,7 @@ output "federation_id" {
 - `remote_trust_zone_id` (String) The ID of the associated remote trust zone.
 - `trust_zone_id` (String) The ID of the associated trust zone.
 
-### Optional
-
-- `org_id` (String) The ID of the organization.
-
 ### Read-Only
 
 - `id` (String) The ID of the federation.
+- `org_id` (String) The ID of the organization. Derived from the trust zone by Cofide Connect.

--- a/internal/services/apbinding/resource.go
+++ b/internal/services/apbinding/resource.go
@@ -7,7 +7,6 @@ import (
 	apbindingpb "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	apbindinginsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/ap_binding_service/v1alpha1"
 	sdkclient "github.com/cofide/cofide-api-sdk/pkg/connect/client"
-	"github.com/cofide/terraform-provider-cofide/internal/util"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	tftypes "github.com/hashicorp/terraform-plugin-framework/types"
@@ -68,10 +67,6 @@ func (a *APBindingResource) Create(ctx context.Context, req resource.CreateReque
 		TrustZoneId: plan.TrustZoneID.ValueStringPointer(),
 		PolicyId:    plan.PolicyID.ValueStringPointer(),
 		Federations: federations,
-	}
-
-	if util.IsStringAttributeNonEmpty(plan.OrgID) {
-		binding.OrgId = plan.OrgID.ValueStringPointer()
 	}
 
 	createResp, err := a.client.APBindingV1Alpha1().CreateAPBinding(ctx, binding)
@@ -189,28 +184,15 @@ func (a *APBindingResource) Update(ctx context.Context, req resource.UpdateReque
 		Federations: federations,
 	}
 
-	if util.IsStringAttributeNonEmpty(plan.OrgID) {
-		binding.OrgId = plan.OrgID.ValueStringPointer()
-	}
-
 	updateResp, err := a.client.APBindingV1Alpha1().UpdateAPBinding(ctx, binding)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating AP binding", err.Error())
 		return
 	}
 
-	var orgIDStr tftypes.String
-	if orgID := updateResp.GetOrgId(); orgID != "" {
-		orgIDStr = tftypes.StringValue(orgID)
-	} else if !plan.OrgID.IsNull() {
-		orgIDStr = plan.OrgID
-	} else {
-		orgIDStr = tftypes.StringNull()
-	}
-
 	newState := APBindingModel{
 		ID:          tftypes.StringValue(updateResp.GetId()),
-		OrgID:       orgIDStr,
+		OrgID:       tftypes.StringValue(updateResp.GetOrgId()),
 		TrustZoneID: tftypes.StringValue(updateResp.GetTrustZoneId()),
 		PolicyID:    tftypes.StringValue(updateResp.GetPolicyId()),
 	}

--- a/internal/services/apbinding/schema.go
+++ b/internal/services/apbinding/schema.go
@@ -3,7 +3,6 @@ package apbinding
 import (
 	"context"
 
-	"github.com/cofide/terraform-provider-cofide/internal/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -26,11 +25,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"org_id": schema.StringAttribute{
-				Description: "The ID of the organization.",
-				Optional:    true,
+				Description: "The ID of the organization. Derived from the trust zone by Cofide Connect.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					planmodifiers.OptionalComputedModifier{},
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},

--- a/internal/services/cluster/resource.go
+++ b/internal/services/cluster/resource.go
@@ -70,10 +70,6 @@ func (c *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 		ExternalServer:    plan.ExternalServer.ValueBoolPointer(),
 	}
 
-	if util.IsStringAttributeNonEmpty(plan.OrgID) {
-		cluster.OrgId = plan.OrgID.ValueStringPointer()
-	}
-
 	if util.IsStringAttributeNonEmpty(plan.OidcIssuerURL) {
 		cluster.OidcIssuerUrl = plan.OidcIssuerURL.ValueStringPointer()
 	}
@@ -247,10 +243,6 @@ func (c *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 		KubernetesContext: plan.KubernetesContext.ValueStringPointer(),
 		Profile:           plan.Profile.ValueStringPointer(),
 		ExternalServer:    plan.ExternalServer.ValueBoolPointer(),
-	}
-
-	if util.IsStringAttributeNonEmpty(plan.OrgID) {
-		cluster.OrgId = plan.OrgID.ValueStringPointer()
 	}
 
 	if util.IsStringAttributeNonEmpty(plan.OidcIssuerURL) {

--- a/internal/services/cluster/schema.go
+++ b/internal/services/cluster/schema.go
@@ -33,11 +33,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Required:    true,
 			},
 			"org_id": schema.StringAttribute{
-				Description: "The ID of the organization.",
-				Optional:    true,
+				Description: "The ID of the organization. Derived from the trust zone by Cofide Connect.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					planmodifiers.OptionalComputedModifier{},
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},

--- a/internal/services/federation/resource.go
+++ b/internal/services/federation/resource.go
@@ -60,10 +60,6 @@ func (f *FederationResource) Create(ctx context.Context, req resource.CreateRequ
 		RemoteTrustZoneId: plan.RemoteTrustZoneID.ValueStringPointer(),
 	}
 
-	if !plan.OrgID.IsNull() {
-		federation.OrgId = plan.OrgID.ValueStringPointer()
-	}
-
 	createResp, err := f.client.FederationV1Alpha1().CreateFederation(ctx, federation)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/federation/schema.go
+++ b/internal/services/federation/schema.go
@@ -3,7 +3,6 @@ package federation
 import (
 	"context"
 
-	"github.com/cofide/terraform-provider-cofide/internal/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -24,11 +23,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"org_id": schema.StringAttribute{
-				Description: "The ID of the organization.",
-				Optional:    true,
+				Description: "The ID of the organization. Derived from the trust zone by Cofide Connect.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					planmodifiers.OptionalComputedModifier{},
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},


### PR DESCRIPTION
Org ID should not be set by consumers on cluster / federation / attestation policy binding resources - instead the server derives it from the parent resource(s).

Setting it on send isn't an error (server ignores it), but the attribute not being read-only is misleading/confusing.