### PR TITLE
chore: update Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/terraform-provider-cofide
 
-go 1.25.11
+go 1.26.5
 
 require (
 	github.com/cofide/cofide-api-sdk v0.59.0


### PR DESCRIPTION
Fixes:

Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.25.11
    Fixed in: crypto/tls@go1.25.12
