### PR TITLE
fix: stop the attestation policy data source drifting from the resource

### DIFF
--- a/docs/data-sources/connect_attestation_policy.md
+++ b/docs/data-sources/connect_attestation_policy.md
@@ -126,6 +126,7 @@ Read-Only:
 - `parent_id_path` (String) The SPIFFE ID path of the parent node for workloads matching this policy.
 - `selectors` (Attributes List) The list of selectors for the static attestation policy. (see [below for nested schema](#nestedatt--static--selectors))
 - `spiffe_id_path` (String) The SPIFFE ID path assigned to workloads matching this policy (e.g. `ns/default/sa/my-service-account`).
+- `store_svid` (Boolean) When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if an svidstore agent plugin is enabled). Defaults to false.
 
 <a id="nestedatt--static--selectors"></a>
 ### Nested Schema for `static.selectors`

--- a/internal/services/attestationpolicy/data_source.go
+++ b/internal/services/attestationpolicy/data_source.go
@@ -7,7 +7,6 @@ import (
 	attestationpolicysvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/attestation_policy_service/v1alpha1"
 	sdkclient "github.com/cofide/cofide-api-sdk/pkg/connect/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type AttestationPolicyDataSource struct {
@@ -87,32 +86,9 @@ func (d *AttestationPolicyDataSource) Read(ctx context.Context, req datasource.R
 		return
 	}
 
-	state := AttestationPolicyModel{
-		ID:    types.StringValue(policy.GetId()),
-		Name:  types.StringValue(policy.GetName()),
-		OrgID: types.StringValue(policy.GetOrgId()),
-	}
-
-	if k8s := policy.GetKubernetes(); k8s != nil {
-		state.Kubernetes = &APKubernetesModel{}
-		if ns := k8s.GetNamespaceSelector(); ns != nil {
-			state.Kubernetes.NamespaceSelector = convertProtoLabelSelector(ns)
-		}
-		if ps := k8s.GetPodSelector(); ps != nil {
-			state.Kubernetes.PodSelector = convertProtoLabelSelector(ps)
-		}
-		state.Kubernetes.DnsNameTemplates = convertProtoSelectorValues(k8s.GetDnsNameTemplates())
-		state.Kubernetes.SpiffeIDPathTemplate = types.StringValue(k8s.GetSpiffeIdPathTemplate())
-	}
-
-	if static := policy.GetStatic(); static != nil {
-		state.Static = &APStaticModel{
-			SpiffeIDPath: types.StringValue(static.GetSpiffeIdPath()),
-			ParentIdPath: types.StringValue(static.GetParentIdPath()),
-			Selectors:    convertProtoSelectors(static.GetSelectors()),
-			DNSNames:     convertProtoSelectorValues(static.GetDnsNames()),
-		}
-	}
+	// Use the shared conversion rather than an inline copy, so the data source
+	// cannot drift from the resource as policy fields are added.
+	state := protoToModel(policy)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/services/attestationpolicy/data_source_schema.go
+++ b/internal/services/attestationpolicy/data_source_schema.go
@@ -138,6 +138,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						Computed:    true,
 						ElementType: tftypes.StringType,
 					},
+					"store_svid": schema.BoolAttribute{
+						Description: "When true, indicates to SPIRE agents that the x509 SVID should be stored in the svidstore (if an svidstore agent plugin is enabled). Defaults to false.",
+						Computed:    true,
+					},
 				},
 			},
 			"tpm_node": schema.SingleNestedAttribute{

--- a/test/connect_attestation_policy/assertions.sh
+++ b/test/connect_attestation_policy/assertions.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+dir=${1?Specify test Terraform directory}
+
+outputs=$(terraform -chdir="$dir" output -json)
+
+assert_eq() {
+  local key=$1
+  local expected=$2
+  local actual
+  actual=$(echo "$outputs" | jq -r ".$key.value")
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: output '$key': expected '$expected', got '$actual'" >&2
+    return 1
+  fi
+}
+
+assert_jq_eq() {
+  local filter=$1
+  local expected=$2
+  local actual
+  actual=$(echo "$outputs" | jq -r "$filter")
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: '$filter': expected '$expected', got '$actual'" >&2
+    return 1
+  fi
+}
+
+assert_not_empty() {
+  local key=$1
+  local actual
+  actual=$(echo "$outputs" | jq -r ".$key.value")
+  if [[ -z "$actual" || "$actual" == "null" ]]; then
+    echo "ERROR: output '$key': expected non-empty value" >&2
+    return 1
+  fi
+}
+
+assert_not_empty "attestation_policy_static_id"
+assert_not_empty "attestation_policy_kubernetes_id"
+
+# store_svid round-trips through both the resource and the data source. The
+# data source read is the interesting half: it is served by a separate schema,
+# which omitted store_svid entirely until this was covered.
+assert_eq "attestation_policy_static_store_svid_resource" "true"
+assert_eq "attestation_policy_static_store_svid_data_source" "true"
+
+# The data source ignored tpm_node policies entirely before it was switched to
+# the shared conversion.
+assert_eq "attestation_policy_tpm_node_ek_hash" \
+  "5b3e0a049837688b09028ba84be190720bcc8f6cf74a487dc53b2ce9f376b5fb"
+
+selector_count=$(echo "$outputs" | jq '.attestation_policy_tpm_node_selector_values.value | length')
+if [[ "$selector_count" != "1" ]]; then
+  echo "ERROR: expected 1 tpm_node selector value, got $selector_count" >&2
+  exit 1
+fi
+assert_jq_eq ".attestation_policy_tpm_node_selector_values.value[0]" "test-selector"
+
+assert_eq "attestation_policy_kubernetes_spiffe_id_path_template" "test/workload"

--- a/test/connect_attestation_policy/main.tf
+++ b/test/connect_attestation_policy/main.tf
@@ -22,6 +22,7 @@ resource "cofide_connect_attestation_policy" "attestation_policy_static" {
     dns_names = [
       "test.workload"
     ]
+    store_svid = true
   }
 }
 
@@ -63,7 +64,7 @@ resource "cofide_connect_attestation_policy" "attestation_policy_tpm_node" {
 # Use a variable rather than a literal list of strings for selector values to
 # cover https://github.com/cofide/terraform-provider-cofide/issues/113.
 variable "selector_values" {
-  type = list(string)
+  type    = list(string)
   default = ["test-selector"]
 }
 
@@ -85,10 +86,42 @@ data "cofide_connect_attestation_policy" "attestation_policy_kubernetes" {
   ]
 }
 
+data "cofide_connect_attestation_policy" "attestation_policy_tpm_node" {
+  name   = "test-ap-3"
+  org_id = data.cofide_connect_organization.org.id
+
+  depends_on = [
+    cofide_connect_attestation_policy.attestation_policy_tpm_node
+  ]
+}
+
 output "attestation_policy_static_id" {
   value = data.cofide_connect_attestation_policy.attestation_policy_static.id
 }
 
 output "attestation_policy_kubernetes_id" {
   value = data.cofide_connect_attestation_policy.attestation_policy_kubernetes.id
+}
+
+# store_svid, as read back from the resource state and from the data source.
+output "attestation_policy_static_store_svid_resource" {
+  value = cofide_connect_attestation_policy.attestation_policy_static.static.store_svid
+}
+
+output "attestation_policy_static_store_svid_data_source" {
+  value = data.cofide_connect_attestation_policy.attestation_policy_static.static.store_svid
+}
+
+# The data source previously ignored tpm_node policies altogether.
+output "attestation_policy_tpm_node_ek_hash" {
+  value = data.cofide_connect_attestation_policy.attestation_policy_tpm_node.tpm_node.attestation.ek_hash
+}
+
+output "attestation_policy_tpm_node_selector_values" {
+  value = data.cofide_connect_attestation_policy.attestation_policy_tpm_node.tpm_node.selector_values
+}
+
+# The kubernetes policy, read back through the data source.
+output "attestation_policy_kubernetes_spiffe_id_path_template" {
+  value = data.cofide_connect_attestation_policy.attestation_policy_kubernetes.kubernetes.spiffe_id_path_template
 }


### PR DESCRIPTION
The data source Read built its state with an inline copy of the
proto-to-model conversion, which had drifted from protoToModel in two
ways:

- static.store_svid was never set, and was missing from the data source
  schema entirely, so reading a static policy failed with a Value
  Conversion Error: "Struct defines fields not found in object:
  store_svid".
- tpm_node policies were ignored, so those read back with no policy at
  all.

Adds store_svid to the data source schema, and replaces the inline copy
with protoToModel, which the resource already uses, so the two cannot
drift again as fields are added.

Covers both in the integration test: the static policy now sets
store_svid and asserts it round-trips through the resource and the data
source, and the tpm_node policy gains a data source read with assertions
on tpm_node and the kubernetes spiffe_id_path_template.

Note this also makes unset optional string fields read back as null
rather than "", matching the resource's behaviour.
