### PR TITLE
fix(test): drop org_id from resources where it is read-only

### DIFF
--- a/docs/resources/connect_ap_binding.md
+++ b/docs/resources/connect_ap_binding.md
@@ -26,12 +26,6 @@ terraform {
 provider "cofide" {}
 
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "trust_zone_id" {
   description = "The ID of the trust zone."
   type        = string
@@ -46,7 +40,6 @@ variable "policy_id" {
 
 
 resource "cofide_connect_ap_binding" "example" {
-  org_id        = var.org_id
   trust_zone_id = var.trust_zone_id
   policy_id     = var.policy_id
 }
@@ -71,12 +64,6 @@ terraform {
 provider "cofide" {}
 
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "trust_zone_id" {
   description = "The ID of the trust zone."
   type        = string
@@ -97,7 +84,6 @@ variable "remote_trust_zone_id" {
 
 
 resource "cofide_connect_ap_binding" "example" {
-  org_id        = var.org_id
   trust_zone_id = var.trust_zone_id
   policy_id     = var.policy_id
 

--- a/docs/resources/connect_cluster.md
+++ b/docs/resources/connect_cluster.md
@@ -38,12 +38,6 @@ variable "trust_zone_id" {
   default     = "example-tz-id"
 }
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "kubernetes_context" {
   description = "The Kubernetes context to use."
   type        = string
@@ -54,7 +48,6 @@ variable "kubernetes_context" {
 resource "cofide_connect_cluster" "example" {
   name               = var.name
   trust_zone_id      = var.trust_zone_id
-  org_id             = var.org_id
   profile            = "kubernetes"
   kubernetes_context = var.kubernetes_context
   external_server    = false
@@ -96,12 +89,6 @@ variable "trust_zone_id" {
   default     = "example-tz-id"
 }
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "kubernetes_context" {
   description = "The Kubernetes context to use."
   type        = string
@@ -118,7 +105,6 @@ variable "oidc_issuer_url" {
 resource "cofide_connect_cluster" "example" {
   name                = var.name
   trust_zone_id       = var.trust_zone_id
-  org_id              = var.org_id
   profile             = "kubernetes"
   kubernetes_context  = var.kubernetes_context
   external_server     = false

--- a/docs/resources/connect_federation.md
+++ b/docs/resources/connect_federation.md
@@ -26,12 +26,6 @@ terraform {
 provider "cofide" {}
 
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "trust_zone_id" {
   description = "The ID of the trust zone."
   type        = string
@@ -46,7 +40,6 @@ variable "remote_trust_zone_id" {
 
 
 resource "cofide_connect_federation" "example" {
-  org_id               = var.org_id
   trust_zone_id        = var.trust_zone_id
   remote_trust_zone_id = var.remote_trust_zone_id
 }

--- a/examples/resources/cofide_connect_ap_binding/default/main.tf
+++ b/examples/resources/cofide_connect_ap_binding/default/main.tf
@@ -1,5 +1,4 @@
 resource "cofide_connect_ap_binding" "example" {
-  org_id        = var.org_id
   trust_zone_id = var.trust_zone_id
   policy_id     = var.policy_id
 }

--- a/examples/resources/cofide_connect_ap_binding/default/variables.tf
+++ b/examples/resources/cofide_connect_ap_binding/default/variables.tf
@@ -1,9 +1,3 @@
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "trust_zone_id" {
   description = "The ID of the trust zone."
   type        = string

--- a/examples/resources/cofide_connect_ap_binding/with_federations/main.tf
+++ b/examples/resources/cofide_connect_ap_binding/with_federations/main.tf
@@ -1,5 +1,4 @@
 resource "cofide_connect_ap_binding" "example" {
-  org_id        = var.org_id
   trust_zone_id = var.trust_zone_id
   policy_id     = var.policy_id
 

--- a/examples/resources/cofide_connect_ap_binding/with_federations/variables.tf
+++ b/examples/resources/cofide_connect_ap_binding/with_federations/variables.tf
@@ -1,9 +1,3 @@
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "trust_zone_id" {
   description = "The ID of the trust zone."
   type        = string

--- a/examples/resources/cofide_connect_cluster/default/main.tf
+++ b/examples/resources/cofide_connect_cluster/default/main.tf
@@ -1,7 +1,6 @@
 resource "cofide_connect_cluster" "example" {
   name               = var.name
   trust_zone_id      = var.trust_zone_id
-  org_id             = var.org_id
   profile            = "kubernetes"
   kubernetes_context = var.kubernetes_context
   external_server    = false

--- a/examples/resources/cofide_connect_cluster/default/variables.tf
+++ b/examples/resources/cofide_connect_cluster/default/variables.tf
@@ -10,12 +10,6 @@ variable "trust_zone_id" {
   default     = "example-tz-id"
 }
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "kubernetes_context" {
   description = "The Kubernetes context to use."
   type        = string

--- a/examples/resources/cofide_connect_cluster/with_helm_values/main.tf
+++ b/examples/resources/cofide_connect_cluster/with_helm_values/main.tf
@@ -1,7 +1,6 @@
 resource "cofide_connect_cluster" "example" {
   name                = var.name
   trust_zone_id       = var.trust_zone_id
-  org_id              = var.org_id
   profile             = "kubernetes"
   kubernetes_context  = var.kubernetes_context
   external_server     = false

--- a/examples/resources/cofide_connect_cluster/with_helm_values/variables.tf
+++ b/examples/resources/cofide_connect_cluster/with_helm_values/variables.tf
@@ -10,12 +10,6 @@ variable "trust_zone_id" {
   default     = "example-tz-id"
 }
 
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "kubernetes_context" {
   description = "The Kubernetes context to use."
   type        = string

--- a/examples/resources/cofide_connect_federation/main.tf
+++ b/examples/resources/cofide_connect_federation/main.tf
@@ -1,5 +1,4 @@
 resource "cofide_connect_federation" "example" {
-  org_id               = var.org_id
   trust_zone_id        = var.trust_zone_id
   remote_trust_zone_id = var.remote_trust_zone_id
 }

--- a/examples/resources/cofide_connect_federation/variables.tf
+++ b/examples/resources/cofide_connect_federation/variables.tf
@@ -1,9 +1,3 @@
-variable "org_id" {
-  description = "The ID of the organization."
-  type        = string
-  default     = "example-org-id"
-}
-
 variable "trust_zone_id" {
   description = "The ID of the trust zone."
   type        = string

--- a/test/connect_ap_binding/main.tf
+++ b/test/connect_ap_binding/main.tf
@@ -39,7 +39,6 @@ resource "cofide_connect_attestation_policy" "attestation_policy_static" {
 }
 
 resource "cofide_connect_ap_binding" "ap_binding" {
-  org_id        = data.cofide_connect_organization.org.id
   trust_zone_id = cofide_connect_trust_zone.trust_zone.id
   policy_id     = cofide_connect_attestation_policy.attestation_policy_static.id
   federations = [

--- a/test/connect_cluster/main.tf
+++ b/test/connect_cluster/main.tf
@@ -10,7 +10,6 @@ resource "cofide_connect_trust_zone" "trust_zone" {
 
 resource "cofide_connect_cluster" "cluster" {
   name               = "test-cluster"
-  org_id             = data.cofide_connect_organization.org.id
   trust_zone_id      = cofide_connect_trust_zone.trust_zone.id
   profile            = "kubernetes"
   kubernetes_context = "test-cluster-context"
@@ -56,8 +55,8 @@ resource "cofide_connect_cluster" "cluster" {
 }
 
 data "cofide_connect_cluster" "cluster" {
-  name          = cofide_connect_cluster.cluster.name
-  org_id        = data.cofide_connect_organization.org.id
+  name   = cofide_connect_cluster.cluster.name
+  org_id = data.cofide_connect_organization.org.id
 
   depends_on = [
     cofide_connect_cluster.cluster

--- a/test/connect_federation/main.tf
+++ b/test/connect_federation/main.tf
@@ -15,7 +15,6 @@ resource "cofide_connect_trust_zone" "trust_zone_b" {
 }
 
 resource "cofide_connect_federation" "federation" {
-  org_id               = cofide_connect_trust_zone.trust_zone_a.org_id
   trust_zone_id        = cofide_connect_trust_zone.trust_zone_a.id
   remote_trust_zone_id = cofide_connect_trust_zone.trust_zone_b.id
 }

--- a/test/connect_trust_zone_server/main.tf
+++ b/test/connect_trust_zone_server/main.tf
@@ -10,7 +10,6 @@ resource "cofide_connect_trust_zone" "trust_zone" {
 
 resource "cofide_connect_cluster" "cluster" {
   name               = "tzserver-cluster"
-  org_id             = data.cofide_connect_organization.org.id
   trust_zone_id      = cofide_connect_trust_zone.trust_zone.id
   profile            = "kubernetes"
   kubernetes_context = "tzserver-cluster-context"
@@ -37,7 +36,7 @@ resource "cofide_connect_trust_zone_server" "server" {
   })
 
   connect_k8s_psat_config = {
-    audiences                  = ["spire-server"]
+    audiences                   = ["spire-server"]
     spire_server_spiffe_id_path = "/ns/spire/sa/spire-server"
   }
 }


### PR DESCRIPTION
Fixes the examples and integration tests.

bcb5e12 made org_id computed-only on child resources, since Connect
derives it from the parent, but left the test and example configurations
setting it. Terraform rejects these with "Invalid Configuration for
Read-Only Attribute", so the cluster, ap_binding, federation and
trust_zone_server integration tests all failed to apply.

Removes org_id from the affected resource blocks in test/ and examples/,
along with the now-unused org_id variables, and regenerates the docs.
Data source blocks are untouched: org_id remains an optional filter
there.
