### PR TITLE
test: assert resource and data source schemas describe the same shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ This is a Terraform provider built with `terraform-plugin-framework` that manage
 - `schema.go` — defines the Terraform schema for the resource
 - `data_source_schema.go` — defines the schema for the data source
 - `model.go` — defines the Go struct (`*Model`) that maps to Terraform state via `tfsdk:` tags
-- `convert.go` — bidirectional conversion between the model and the protobuf API types (not all resources have this; simpler ones do conversion inline)
+- `convert.go` — bidirectional conversion between the model and the protobuf API types (some resources still do conversion inline, but new code should use `convert.go` — see Key conventions)
 
 **Protobuf types**: Come from `github.com/cofide/cofide-api-sdk/gen/go/proto/...`. Each resource calls the corresponding versioned SDK client (e.g. `t.client.TrustZoneV1Alpha1()`).
 
@@ -58,6 +58,8 @@ This is a Terraform provider built with `terraform-plugin-framework` that manage
 
 ## Key conventions
 
+- A resource and its data sources share one `*Model` struct, so their schemas must describe the same shape. Data source schemas mirror the resource schema attribute for attribute, differing only in `Required`/`Optional`/`Computed` and plan modifiers. List data sources nest that same shape under a list attribute, alongside their filter attributes. `internal/schema_shape_test.go` enforces this; add new resources to its table.
+- Proto-to-model conversion lives in a single `protoToModel` in `convert.go`, used by both the resource `Read`/`Create`/`Update` and the data source `Read`. Do not hand-roll a second copy in `data_source.go`: the copies drift, and the resulting bugs (a missing field, or a whole oneof variant silently dropped) only surface against a live Connect deployment.
 - Resources that support `ImportState` use `resource.ImportStatePassthroughID` to import by ID.
 - gRPC `codes.NotFound` on Read removes the resource from state (drift detection), rather than erroring.
 - Provider config can be supplied via HCL attributes or environment variables (`COFIDE_API_TOKEN`, `COFIDE_CONNECT_URL`, `COFIDE_INSECURE_SKIP_VERIFY`).

--- a/internal/schema_shape_test.go
+++ b/internal/schema_shape_test.go
@@ -1,0 +1,110 @@
+package internal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cofide/terraform-provider-cofide/internal/services/apbinding"
+	"github.com/cofide/terraform-provider-cofide/internal/services/attestationpolicy"
+	"github.com/cofide/terraform-provider-cofide/internal/services/cluster"
+	"github.com/cofide/terraform-provider-cofide/internal/services/exchangepolicy"
+	"github.com/cofide/terraform-provider-cofide/internal/services/federation"
+	"github.com/cofide/terraform-provider-cofide/internal/services/trustzone"
+	"github.com/cofide/terraform-provider-cofide/internal/services/trustzoneserver"
+)
+
+// TestSchemaShapesMatch asserts that each resource schema and the data source
+// schema(s) for the same resource describe an identical object shape.
+//
+// A resource and its data sources share a single *Model struct, so a field
+// present in one schema but not the other makes reading fail at runtime with a
+// Value Conversion Error. The two schemas differ legitimately only in
+// Required/Optional/Computed and plan modifiers, neither of which affects the
+// shape compared here.
+func TestSchemaShapesMatch(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		resource   attr.Type
+		dataSource attr.Type
+	}{
+		{
+			name:       "apbinding",
+			resource:   apbinding.ResourceSchema(ctx).Type(),
+			dataSource: apbinding.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "attestationpolicy",
+			resource:   attestationpolicy.ResourceSchema(ctx).Type(),
+			dataSource: attestationpolicy.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "cluster",
+			resource:   cluster.ResourceSchema(ctx).Type(),
+			dataSource: cluster.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "exchangepolicy",
+			resource:   exchangepolicy.ResourceSchema().Type(),
+			dataSource: exchangepolicy.DataSourceSchema().Type(),
+		},
+		{
+			name:       "federation",
+			resource:   federation.ResourceSchema(ctx).Type(),
+			dataSource: federation.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "trustzone",
+			resource:   trustzone.ResourceSchema(ctx).Type(),
+			dataSource: trustzone.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "trustzoneserver",
+			resource:   trustzoneserver.ResourceSchema(ctx).Type(),
+			dataSource: trustzoneserver.DataSourceSchema(ctx).Type(),
+		},
+		// List data sources nest the same model under a list attribute, so
+		// compare the element type rather than the top-level schema.
+		{
+			name:       "exchangepolicy list",
+			resource:   exchangepolicy.ResourceSchema().Type(),
+			dataSource: listElementType(t, exchangepolicy.ListDataSourceSchema().Type(), "exchange_policies"),
+		},
+		{
+			name:       "trustzoneserver list",
+			resource:   trustzoneserver.ResourceSchema(ctx).Type(),
+			dataSource: listElementType(t, trustzoneserver.ListDataSourceSchema(ctx).Type(), "trust_zone_servers"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !test.resource.Equal(test.dataSource) {
+				t.Errorf("resource and data source schemas describe different shapes\nresource:    %s\ndata source: %s",
+					test.resource, test.dataSource)
+			}
+		})
+	}
+}
+
+// listElementType returns the element type of the named list attribute of an
+// object type.
+func listElementType(t *testing.T, schemaType attr.Type, attrName string) attr.Type {
+	t.Helper()
+
+	object, ok := schemaType.(types.ObjectType)
+	require.True(t, ok, "expected an object type, got %s", schemaType)
+
+	attribute, ok := object.AttributeTypes()[attrName]
+	require.True(t, ok, "no %q attribute in %s", attrName, schemaType)
+
+	list, ok := attribute.(types.ListType)
+	require.True(t, ok, "expected %q to be a list type, got %s", attrName, attribute)
+
+	return list.ElementType()
+}

--- a/internal/services/exchangepolicy/data_source_schema.go
+++ b/internal/services/exchangepolicy/data_source_schema.go
@@ -11,7 +11,7 @@ import (
 var _ datasource.DataSource = &ExchangePolicyDataSource{}
 var _ datasource.DataSource = &ExchangePoliciesDataSource{}
 
-func dataSourceSchema() schema.Schema {
+func DataSourceSchema() schema.Schema {
 	attrs := exchangePolicyNestedAttributes()
 	attrs["id"] = schema.StringAttribute{
 		Description: "The ID of the exchange policy.",
@@ -23,7 +23,7 @@ func dataSourceSchema() schema.Schema {
 	}
 }
 
-func listDataSourceSchema() schema.Schema {
+func ListDataSourceSchema() schema.Schema {
 	return schema.Schema{
 		MarkdownDescription: "Provides information about Cofide Connect exchange policies.",
 		Attributes: map[string]schema.Attribute{
@@ -148,9 +148,9 @@ func stringSetDataSourceAttribute(description string) schema.Attribute {
 }
 
 func (d *ExchangePolicyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = dataSourceSchema()
+	resp.Schema = DataSourceSchema()
 }
 
 func (d *ExchangePoliciesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = listDataSourceSchema()
+	resp.Schema = ListDataSourceSchema()
 }

--- a/internal/services/exchangepolicy/schema.go
+++ b/internal/services/exchangepolicy/schema.go
@@ -51,7 +51,7 @@ func (authExactlyOneVariantValidator) ValidateObject(_ context.Context, req vali
 	}
 }
 
-func resourceSchema() schema.Schema {
+func ResourceSchema() schema.Schema {
 	return schema.Schema{
 		MarkdownDescription: "Manages a Cofide Connect exchange policy. Exchange policies govern Credex token exchanges within a trust zone by specifying match conditions on inbound tokens and determining whether exchanges are permitted or denied.",
 		Attributes: map[string]schema.Attribute{
@@ -192,5 +192,5 @@ func stringSetResourceAttribute(description string) schema.Attribute {
 }
 
 func (r *ExchangePolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resourceSchema()
+	resp.Schema = ResourceSchema()
 }


### PR DESCRIPTION
A resource and its data sources share a single *Model struct, so a field
present in one schema but not the other makes reading fail at runtime
with a Value Conversion Error. That is how the attestation policy data
source came to omit static.store_svid: nothing forced the two schemas to
agree, and the mismatch only surfaced against a live Connect deployment.

Adds a table-driven test comparing each resource schema's attr.Type with
that of its data source schema. The two differ legitimately only in
Required/Optional/Computed and plan modifiers, neither of which affects
the shape compared here. List data sources nest the same model under a
list attribute, so those cases compare the list's element type.

Verified against both drift directions: removing store_svid from the
attestation policy data source schema fails the attestationpolicy case,
and removing id from the trust zone server list schema fails the
trustzoneserver list case. All nine cases pass as they stand, so this
lands green.

Exports exchangepolicy's schema functions so the test can reach them,
matching the other services, which already export theirs.

Documents both halves of the invariant in AGENTS.md: that data source
schemas mirror the resource schema, and that proto-to-model conversion
belongs in a single protoToModel in convert.go used by the resource and
the data source alike. The architecture notes previously read as
sanctioning inline conversion in simpler resources, which is what let
the two copies drift.
