### PR TITLE
test: assert every schema can be read into its model struct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ This is a Terraform provider built with `terraform-plugin-framework` that manage
 - `schema.go` — defines the Terraform schema for the resource
 - `data_source_schema.go` — defines the schema for the data source
 - `model.go` — defines the Go struct (`*Model`) that maps to Terraform state via `tfsdk:` tags
-- `convert.go` — bidirectional conversion between the model and the protobuf API types (not all resources have this; simpler ones do conversion inline)
+- `convert.go` — bidirectional conversion between the model and the protobuf API types (some resources still do conversion inline, but new code should use `convert.go` — see Key conventions)
 
 **Protobuf types**: Come from `github.com/cofide/cofide-api-sdk/gen/go/proto/...`. Each resource calls the corresponding versioned SDK client (e.g. `t.client.TrustZoneV1Alpha1()`).
 
@@ -58,6 +58,8 @@ This is a Terraform provider built with `terraform-plugin-framework` that manage
 
 ## Key conventions
 
+- A resource and its data sources share one `*Model` struct, so their schemas must describe the same shape. Data source schemas mirror the resource schema attribute for attribute, differing only in `Required`/`Optional`/`Computed` and plan modifiers. List data sources nest that same shape under a list attribute, alongside their filter attributes. `internal/schema_shape_test.go` enforces this; add new resources to its table.
+- Proto-to-model conversion lives in a single `protoToModel` in `convert.go`, used by both the resource `Read`/`Create`/`Update` and the data source `Read`. Do not hand-roll a second copy in `data_source.go`: the copies drift, and the resulting bugs (a missing field, or a whole oneof variant silently dropped) only surface against a live Connect deployment.
 - Resources that support `ImportState` use `resource.ImportStatePassthroughID` to import by ID.
 - gRPC `codes.NotFound` on Read removes the resource from state (drift detection), rather than erroring.
 - Provider config can be supplied via HCL attributes or environment variables (`COFIDE_API_TOKEN`, `COFIDE_CONNECT_URL`, `COFIDE_INSECURE_SKIP_VERIFY`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ This is a Terraform provider built with `terraform-plugin-framework` that manage
 
 ## Key conventions
 
-- A resource and its data sources share one `*Model` struct, so their schemas must describe the same shape. Data source schemas mirror the resource schema attribute for attribute, differing only in `Required`/`Optional`/`Computed` and plan modifiers. List data sources nest that same shape under a list attribute, alongside their filter attributes. `internal/schema_shape_test.go` enforces this; add new resources to its table.
+- A resource and its data sources share one `*Model` struct, so their schemas must describe the same shape. Data source schemas mirror the resource schema attribute for attribute, differing only in `Required`/`Optional`/`Computed` and plan modifiers. List data sources nest that same shape under a list attribute, alongside their filter attributes. `internal/schema_shape_test.go` enforces this; add new resources to its table. `internal/schema_model_test.go` separately anchors every schema to its model struct, catching a field missing from both schemas; add new resources and data sources to its table too.
 - Proto-to-model conversion lives in a single `protoToModel` in `convert.go`, used by both the resource `Read`/`Create`/`Update` and the data source `Read`. Do not hand-roll a second copy in `data_source.go`: the copies drift, and the resulting bugs (a missing field, or a whole oneof variant silently dropped) only surface against a live Connect deployment.
 - Resources that support `ImportState` use `resource.ImportStatePassthroughID` to import by ID.
 - gRPC `codes.NotFound` on Read removes the resource from state (drift detection), rather than erroring.

--- a/internal/schema_model_test.go
+++ b/internal/schema_model_test.go
@@ -1,0 +1,117 @@
+package internal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cofide/terraform-provider-cofide/internal/services/apbinding"
+	"github.com/cofide/terraform-provider-cofide/internal/services/attestationpolicy"
+	"github.com/cofide/terraform-provider-cofide/internal/services/cluster"
+	"github.com/cofide/terraform-provider-cofide/internal/services/exchangepolicy"
+	"github.com/cofide/terraform-provider-cofide/internal/services/federation"
+	"github.com/cofide/terraform-provider-cofide/internal/services/organization"
+	"github.com/cofide/terraform-provider-cofide/internal/services/rolebinding"
+	"github.com/cofide/terraform-provider-cofide/internal/services/trustzone"
+	"github.com/cofide/terraform-provider-cofide/internal/services/trustzoneserver"
+)
+
+// schemaModel pairs a schema with the model struct that Read populates from it.
+type schemaModel struct {
+	name   string
+	schema attr.Type
+	// model must be a pointer to a fresh zero value of the model struct.
+	model any
+}
+
+// TestSchemaMatchesModel asserts that every schema can be read into its model
+// struct without conversion errors.
+//
+// Every Read ends in State.Set, which reflects the model struct against the
+// schema — the same reflection exercised here — and fails if either side has a
+// field the other lacks. That failure
+// otherwise only appears against a live Connect deployment, as a Value
+// Conversion Error at plan or apply time — which is how the attestation policy
+// data source shipped without static.store_svid.
+//
+// This complements TestSchemaShapesMatch: that test compares a resource schema
+// against its data source schema, so it cannot catch a field missing from both.
+// This one anchors each schema to the model independently, and so also covers
+// rolebinding and organization, which have no resource/data source pair.
+//
+// One limitation: fields typed as an untyped collection value (tftypes.List
+// rather than a []SomeModel slice) are opaque to this reflection, so their
+// element attributes are not checked. attestationpolicy's static.selectors is
+// one such field.
+func TestSchemaMatchesModel(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []schemaModel{
+		// Resources.
+		{"apbinding resource", apbinding.ResourceSchema(ctx).Type(), &apbinding.APBindingModel{}},
+		{"attestationpolicy resource", attestationpolicy.ResourceSchema(ctx).Type(), &attestationpolicy.AttestationPolicyModel{}},
+		{"cluster resource", cluster.ResourceSchema(ctx).Type(), &cluster.ClusterModel{}},
+		{"exchangepolicy resource", exchangepolicy.ResourceSchema().Type(), &exchangepolicy.ExchangePolicyModel{}},
+		{"federation resource", federation.ResourceSchema(ctx).Type(), &federation.FederationModel{}},
+		{"rolebinding resource", rolebinding.ResourceSchema().Type(), &rolebinding.RoleBindingModel{}},
+		{"trustzone resource", trustzone.ResourceSchema(ctx).Type(), &trustzone.TrustZoneModel{}},
+		{"trustzoneserver resource", trustzoneserver.ResourceSchema(ctx).Type(), &trustzoneserver.TrustZoneServerModel{}},
+
+		// Data sources.
+		{"apbinding data source", apbinding.DataSourceSchema(ctx).Type(), &apbinding.APBindingModel{}},
+		{"attestationpolicy data source", attestationpolicy.DataSourceSchema(ctx).Type(), &attestationpolicy.AttestationPolicyModel{}},
+		{"cluster data source", cluster.DataSourceSchema(ctx).Type(), &cluster.ClusterModel{}},
+		{"exchangepolicy data source", exchangepolicy.DataSourceSchema().Type(), &exchangepolicy.ExchangePolicyModel{}},
+		{"exchangepolicy list data source", exchangepolicy.ListDataSourceSchema().Type(), &exchangepolicy.ExchangePoliciesDataSourceModel{}},
+		{"federation data source", federation.DataSourceSchema(ctx).Type(), &federation.FederationModel{}},
+		{"organization data source", organization.DataSourceSchema().Type(), &organization.OrganizationModel{}},
+		{"trustzone data source", trustzone.DataSourceSchema(ctx).Type(), &trustzone.TrustZoneModel{}},
+		{"trustzoneserver data source", trustzoneserver.DataSourceSchema(ctx).Type(), &trustzoneserver.TrustZoneServerModel{}},
+		{"trustzoneserver list data source", trustzoneserver.ListDataSourceSchema(ctx).Type(), &trustzoneserver.TrustZoneServersDataSourceModel{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, err := test.schema.ValueFromTerraform(ctx, populatedValue(test.schema.TerraformType(ctx)))
+			require.NoError(t, err)
+
+			object, ok := value.(types.Object)
+			require.True(t, ok, "expected schema to produce an object value, got %T", value)
+
+			diags := object.As(ctx, test.model, basetypes.ObjectAsOptions{})
+			for _, diagnostic := range diags.Errors() {
+				t.Errorf("%s: %s", diagnostic.Summary(), diagnostic.Detail())
+			}
+		})
+	}
+}
+
+// populatedValue builds a value of the given type in which every object is
+// present with null attributes, and every collection holds a single element.
+//
+// Nested structs are only reflected against when the value containing them is
+// non-null, so a wholly null value would skip most of the model. Collections
+// need an element for the same reason.
+func populatedValue(tfType tftypes.Type) tftypes.Value {
+	switch t := tfType.(type) {
+	case tftypes.Object:
+		attrs := make(map[string]tftypes.Value, len(t.AttributeTypes))
+		for name, attrType := range t.AttributeTypes {
+			attrs[name] = populatedValue(attrType)
+		}
+		return tftypes.NewValue(t, attrs)
+	case tftypes.List:
+		return tftypes.NewValue(t, []tftypes.Value{populatedValue(t.ElementType)})
+	case tftypes.Set:
+		return tftypes.NewValue(t, []tftypes.Value{populatedValue(t.ElementType)})
+	case tftypes.Map:
+		return tftypes.NewValue(t, map[string]tftypes.Value{"key": populatedValue(t.ElementType)})
+	default:
+		return tftypes.NewValue(tfType, nil)
+	}
+}

--- a/internal/schema_shape_test.go
+++ b/internal/schema_shape_test.go
@@ -1,0 +1,110 @@
+package internal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cofide/terraform-provider-cofide/internal/services/apbinding"
+	"github.com/cofide/terraform-provider-cofide/internal/services/attestationpolicy"
+	"github.com/cofide/terraform-provider-cofide/internal/services/cluster"
+	"github.com/cofide/terraform-provider-cofide/internal/services/exchangepolicy"
+	"github.com/cofide/terraform-provider-cofide/internal/services/federation"
+	"github.com/cofide/terraform-provider-cofide/internal/services/trustzone"
+	"github.com/cofide/terraform-provider-cofide/internal/services/trustzoneserver"
+)
+
+// TestSchemaShapesMatch asserts that each resource schema and the data source
+// schema(s) for the same resource describe an identical object shape.
+//
+// A resource and its data sources share a single *Model struct, so a field
+// present in one schema but not the other makes reading fail at runtime with a
+// Value Conversion Error. The two schemas differ legitimately only in
+// Required/Optional/Computed and plan modifiers, neither of which affects the
+// shape compared here.
+func TestSchemaShapesMatch(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		resource   attr.Type
+		dataSource attr.Type
+	}{
+		{
+			name:       "apbinding",
+			resource:   apbinding.ResourceSchema(ctx).Type(),
+			dataSource: apbinding.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "attestationpolicy",
+			resource:   attestationpolicy.ResourceSchema(ctx).Type(),
+			dataSource: attestationpolicy.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "cluster",
+			resource:   cluster.ResourceSchema(ctx).Type(),
+			dataSource: cluster.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "exchangepolicy",
+			resource:   exchangepolicy.ResourceSchema().Type(),
+			dataSource: exchangepolicy.DataSourceSchema().Type(),
+		},
+		{
+			name:       "federation",
+			resource:   federation.ResourceSchema(ctx).Type(),
+			dataSource: federation.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "trustzone",
+			resource:   trustzone.ResourceSchema(ctx).Type(),
+			dataSource: trustzone.DataSourceSchema(ctx).Type(),
+		},
+		{
+			name:       "trustzoneserver",
+			resource:   trustzoneserver.ResourceSchema(ctx).Type(),
+			dataSource: trustzoneserver.DataSourceSchema(ctx).Type(),
+		},
+		// List data sources nest the same model under a list attribute, so
+		// compare the element type rather than the top-level schema.
+		{
+			name:       "exchangepolicy list",
+			resource:   exchangepolicy.ResourceSchema().Type(),
+			dataSource: listElementType(t, exchangepolicy.ListDataSourceSchema().Type(), "exchange_policies"),
+		},
+		{
+			name:       "trustzoneserver list",
+			resource:   trustzoneserver.ResourceSchema(ctx).Type(),
+			dataSource: listElementType(t, trustzoneserver.ListDataSourceSchema(ctx).Type(), "trust_zone_servers"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !test.resource.Equal(test.dataSource) {
+				t.Errorf("resource and data source schemas describe different shapes\nresource:    %s\ndata source: %s",
+					test.resource, test.dataSource)
+			}
+		})
+	}
+}
+
+// listElementType returns the element type of the named list attribute of an
+// object type.
+func listElementType(t *testing.T, schemaType attr.Type, attrName string) attr.Type {
+	t.Helper()
+
+	object, ok := schemaType.(types.ObjectType)
+	require.True(t, ok, "expected an object type, got %s", schemaType)
+
+	attribute, ok := object.AttributeTypes()[attrName]
+	require.True(t, ok, "no %q attribute in %s", attrName, schemaType)
+
+	list, ok := attribute.(types.ListType)
+	require.True(t, ok, "expected %q to be a list type, got %s", attrName, attribute)
+
+	return list.ElementType()
+}

--- a/internal/services/exchangepolicy/data_source_schema.go
+++ b/internal/services/exchangepolicy/data_source_schema.go
@@ -11,7 +11,7 @@ import (
 var _ datasource.DataSource = &ExchangePolicyDataSource{}
 var _ datasource.DataSource = &ExchangePoliciesDataSource{}
 
-func dataSourceSchema() schema.Schema {
+func DataSourceSchema() schema.Schema {
 	attrs := exchangePolicyNestedAttributes()
 	attrs["id"] = schema.StringAttribute{
 		Description: "The ID of the exchange policy.",
@@ -23,7 +23,7 @@ func dataSourceSchema() schema.Schema {
 	}
 }
 
-func listDataSourceSchema() schema.Schema {
+func ListDataSourceSchema() schema.Schema {
 	return schema.Schema{
 		MarkdownDescription: "Provides information about Cofide Connect exchange policies.",
 		Attributes: map[string]schema.Attribute{
@@ -148,9 +148,9 @@ func stringSetDataSourceAttribute(description string) schema.Attribute {
 }
 
 func (d *ExchangePolicyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = dataSourceSchema()
+	resp.Schema = DataSourceSchema()
 }
 
 func (d *ExchangePoliciesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = listDataSourceSchema()
+	resp.Schema = ListDataSourceSchema()
 }

--- a/internal/services/exchangepolicy/schema.go
+++ b/internal/services/exchangepolicy/schema.go
@@ -51,7 +51,7 @@ func (authExactlyOneVariantValidator) ValidateObject(_ context.Context, req vali
 	}
 }
 
-func resourceSchema() schema.Schema {
+func ResourceSchema() schema.Schema {
 	return schema.Schema{
 		MarkdownDescription: "Manages a Cofide Connect exchange policy. Exchange policies govern Credex token exchanges within a trust zone by specifying match conditions on inbound tokens and determining whether exchanges are permitted or denied.",
 		Attributes: map[string]schema.Attribute{
@@ -192,5 +192,5 @@ func stringSetResourceAttribute(description string) schema.Attribute {
 }
 
 func (r *ExchangePolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resourceSchema()
+	resp.Schema = ResourceSchema()
 }

--- a/internal/services/organization/data_source.go
+++ b/internal/services/organization/data_source.go
@@ -25,7 +25,7 @@ func (d *OrganizationDataSource) Metadata(ctx context.Context, req datasource.Me
 }
 
 func (d *OrganizationDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = getOrganizationDataSourceSchema()
+	resp.Schema = DataSourceSchema()
 }
 
 func (d *OrganizationDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/services/organization/data_source_schema.go
+++ b/internal/services/organization/data_source_schema.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
 
-func getOrganizationDataSourceSchema() schema.Schema {
+func DataSourceSchema() schema.Schema {
 	return schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Provides information about an organization resource.",

--- a/internal/services/rolebinding/resource.go
+++ b/internal/services/rolebinding/resource.go
@@ -149,7 +149,7 @@ func (r *RoleBindingResource) ImportState(ctx context.Context, req resource.Impo
 }
 
 func (r *RoleBindingResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resourceSchema()
+	resp.Schema = ResourceSchema()
 }
 
 func (r *RoleBindingResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/services/rolebinding/schema.go
+++ b/internal/services/rolebinding/schema.go
@@ -7,7 +7,7 @@ import (
 
 var _ resource.ResourceWithConfigValidators = (*RoleBindingResource)(nil)
 
-func resourceSchema() schema.Schema {
+func ResourceSchema() schema.Schema {
 	return schema.Schema{
 		MarkdownDescription: "Manages a Cofide Connect role binding. Grants a user or group a role on a specific resource. Exactly one of `user` or `group` must be provided.",
 		Attributes: map[string]schema.Attribute{

--- a/internal/services/rolebinding/validators_test.go
+++ b/internal/services/rolebinding/validators_test.go
@@ -81,7 +81,7 @@ func makeValidateRequest(t *testing.T, user, group tftypes.Value) resource.Valid
 	})
 	return resource.ValidateConfigRequest{
 		Config: tfsdk.Config{
-			Schema: resourceSchema(),
+			Schema: ResourceSchema(),
 			Raw:    raw,
 		},
 	}


### PR DESCRIPTION
TestSchemaShapesMatch compares a resource schema against its data source
schema, so it cannot catch a field missing from both, and it has nothing
to compare for rolebinding, which has no data source, or organization,
which has no resource.

Adds a test that instead anchors each schema to the model struct it is
read into. It builds a value of the schema's type and reflects it into
the model, which is the same reflection State.Set performs at the end of
every Read, so a field on one side and not the other fails here rather
than at plan or apply time against a live deployment. Covers all eight
resources and all ten data sources.

The value has to be built with care: nested structs are only reflected
against when the value containing them is non-null, so every object is
present with null attributes and every collection holds one element. A
wholly null value skips most of the model, and in particular would not
have caught the store_svid bug, which sat under a nested attribute.

Verified against three regressions: removing store_svid from the
attestation policy data source schema, removing name from the
organization schema, and adding a field to RoleBindingModel alone. Each
fails the corresponding case with "Struct defines fields not found in
object", the same message the original bug produced at apply time.

Exports organization's and rolebinding's schema functions so the test
can reach them, as was already done for the other services.

One limitation, noted in the test: fields typed as an untyped collection
value rather than a slice of models are opaque to this reflection, so
their element attributes go unchecked. attestationpolicy's
static.selectors is one such field.
