### PR TITLE
fix: add all fields to exchange policy update mask

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ This is a Terraform provider built with `terraform-plugin-framework` that manage
 - gRPC `codes.NotFound` on Read removes the resource from state (drift detection), rather than erroring.
 - Provider config can be supplied via HCL attributes or environment variables (`COFIDE_API_TOKEN`, `COFIDE_CONNECT_URL`, `COFIDE_INSECURE_SKIP_VERIFY`).
 - The gRPC client uses a retry policy on `UNAUTHENTICATED` errors (up to 10 attempts) to handle transient JWKS fetch failures.
+- Resources whose `UpdateFoo` SDK call takes an explicit field mask (e.g. `exchangepolicy`'s `UpdateExchangePolicyRequest_UpdateMask`) must set every mask field to `true`, not just the ones being touched by a given change — the API only applies fields flagged in the mask, so a field omitted here never gets updated even though it's a normal schema attribute. When adding a new schema attribute to such a resource, add it to the mask too; there's a unit test per resource (e.g. `TestNewUpdateMaskCoversAllFields` in `exchangepolicy`) that reflects over the generated mask type and fails if any field is left unset — add an equivalent test for any other resource that uses a field mask.
 
 ## Integration tests
 

--- a/internal/services/exchangepolicy/resource.go
+++ b/internal/services/exchangepolicy/resource.go
@@ -135,19 +135,7 @@ func (r *ExchangePolicyResource) Update(ctx context.Context, req resource.Update
 	}
 	policy.Id = state.ID.ValueString()
 
-	updateMask := &exchangepolicysvcpb.UpdateExchangePolicyRequest_UpdateMask{
-		Name:             true,
-		Action:           true,
-		SubjectIdentity:  true,
-		SubjectIssuer:    true,
-		ActorIdentity:    true,
-		ActorIssuer:      true,
-		ClientId:         true,
-		TargetAudience:   true,
-		OutboundScopes:   true,
-		OutboundIdentity: true,
-		OutboundIssuer:   true,
-	}
+	updateMask := newUpdateMask()
 
 	updateResp, err := r.client.ExchangePolicyV1Alpha1().UpdateExchangePolicy(ctx, policy, updateMask)
 	if err != nil {
@@ -164,6 +152,30 @@ func (r *ExchangePolicyResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+}
+
+// newUpdateMask builds the update mask covering every field the resource can
+// change on update. Kept as its own function (rather than a literal inline in
+// Update) so a unit test can reflect over the generated
+// UpdateExchangePolicyRequest_UpdateMask type and confirm every one of its
+// fields is set here — the update mask has silently drifted from the schema
+// before, and the protobuf-generated struct grows new fields without warning.
+func newUpdateMask() *exchangepolicysvcpb.UpdateExchangePolicyRequest_UpdateMask {
+	return &exchangepolicysvcpb.UpdateExchangePolicyRequest_UpdateMask{
+		Name:             true,
+		Action:           true,
+		SubjectIdentity:  true,
+		SubjectIssuer:    true,
+		SubjectAudience:  true,
+		ActorIdentity:    true,
+		ActorIssuer:      true,
+		ClientId:         true,
+		TargetAudience:   true,
+		OutboundScopes:   true,
+		OutboundIdentity: true,
+		OutboundIssuer:   true,
+		ExternalHooks:    true,
+	}
 }
 
 func (r *ExchangePolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/exchangepolicy/resource_test.go
+++ b/internal/services/exchangepolicy/resource_test.go
@@ -1,0 +1,33 @@
+package exchangepolicy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewUpdateMaskCoversAllFields guards against the update mask silently
+// drifting from the generated proto type: if a new field is added to
+// UpdateExchangePolicyRequest_UpdateMask (e.g. because a new resource
+// attribute was added) but newUpdateMask isn't updated to set it, Connect
+// will never receive changes to that field on update.
+func TestNewUpdateMaskCoversAllFields(t *testing.T) {
+	mask := newUpdateMask()
+
+	v := reflect.ValueOf(mask).Elem()
+	typ := v.Type()
+
+	var unset []string
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if !field.IsExported() || field.Type.Kind() != reflect.Bool {
+			continue
+		}
+		if !v.Field(i).Bool() {
+			unset = append(unset, field.Name)
+		}
+	}
+
+	assert.Empty(t, unset, "newUpdateMask must set every mask field to true; found unset field(s) %v — a new field was likely added to the proto UpdateMask without being wired up here", unset)
+}

--- a/internal/services/trustzoneserver/resource.go
+++ b/internal/services/trustzoneserver/resource.go
@@ -196,12 +196,7 @@ func (r *TrustZoneServerResource) Update(ctx context.Context, req resource.Updat
 		server.ConnectK8SPsatConfig = cfg
 	}
 
-	updateMask := &trustzoneserversvcpb.UpdateTrustZoneServerRequest_UpdateMask{
-		HelmValues:           true,
-		ConnectK8SPsatConfig: true,
-	}
-
-	updateResp, err := r.client.TrustZoneServerV1Alpha1().UpdateTrustZoneServer(ctx, server, updateMask)
+	updateResp, err := r.client.TrustZoneServerV1Alpha1().UpdateTrustZoneServer(ctx, server, newUpdateMask())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating trust zone server",
@@ -216,6 +211,19 @@ func (r *TrustZoneServerResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+// newUpdateMask builds the update mask covering every field the resource can
+// change on update. Kept as its own function (rather than a literal inline in
+// Update) so a unit test can reflect over the generated
+// UpdateTrustZoneServerRequest_UpdateMask type and confirm every one of its
+// fields is set here — the protobuf-generated struct grows new fields
+// without warning, and an omitted field silently stops being updatable.
+func newUpdateMask() *trustzoneserversvcpb.UpdateTrustZoneServerRequest_UpdateMask {
+	return &trustzoneserversvcpb.UpdateTrustZoneServerRequest_UpdateMask{
+		HelmValues:           true,
+		ConnectK8SPsatConfig: true,
+	}
 }
 
 func (r *TrustZoneServerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/trustzoneserver/resource_test.go
+++ b/internal/services/trustzoneserver/resource_test.go
@@ -1,0 +1,33 @@
+package trustzoneserver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewUpdateMaskCoversAllFields guards against the update mask silently
+// drifting from the generated proto type: if a new field is added to
+// UpdateTrustZoneServerRequest_UpdateMask (e.g. because a new resource
+// attribute was added) but newUpdateMask isn't updated to set it, Connect
+// will never receive changes to that field on update.
+func TestNewUpdateMaskCoversAllFields(t *testing.T) {
+	mask := newUpdateMask()
+
+	v := reflect.ValueOf(mask).Elem()
+	typ := v.Type()
+
+	var unset []string
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if !field.IsExported() || field.Type.Kind() != reflect.Bool {
+			continue
+		}
+		if !v.Field(i).Bool() {
+			unset = append(unset, field.Name)
+		}
+	}
+
+	assert.Empty(t, unset, "newUpdateMask must set every mask field to true; found unset field(s) %v — a new field was likely added to the proto UpdateMask without being wired up here", unset)
+}


### PR DESCRIPTION
The exchange policy update mask was missing the SubjectAudience and
ExternalHooks flags, so these fields could not be updated.

Extract each resource's update mask into a newUpdateMask function and
add TestNewUpdateMaskCoversAllFields, which reflects over the
generated proto UpdateMask type and fails if any field is left unset.
This would have caught the exchangepolicy regression where
outbound_identity and outbound_issuer were omitted from the mask; it
also caught subject_audience and external_hooks, which were missing
even before that change. trustzoneserver's mask was already correct
but gets the same guard for future fields. Document the convention in
AGENTS.md for any other resource that adopts a field mask.
