### PR TITLE
Bump Go to 1.26.6 to resolve CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/terraform-provider-cofide
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cofide/cofide-api-sdk v0.64.0


### PR DESCRIPTION
Make goculncheck green again.

Resolves:
 - GO-2026-6090
 - GO-2026-5972